### PR TITLE
First attempt at setting up a macOS Azure build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,25 +139,46 @@ jobs:
     #releaseTag: # Required when compareWith == LastReleaseByTag
 
       
-# - job: UFNLoader_macOS
-#   pool:
-#    vmImage: 'macOS-latest'
-#   steps:
-#   - script: |
-#       echo Build App
-#       cd ./UNFLoader/
-#       ls
-#       make -f Makefile
-#     displayName: 'Build Program'
+ - job: UFNLoader_macOS
+   pool:
+    vmImage: 'macOS-latest'
+   steps:
+   - script: |
+       echo Install helper package
+       curl -L https://www.ftdichip.com/old2020/Drivers/D2XX/MacOSX/D2xxHelper_v2.0.0.pkg --output helper.pkg
+       sudo installer -pkg ./helper.pkg -target /
 
-#   # Publish build artifacts to Azure Artifacts/TFS or a file share
-#   - task: PublishBuildArtifacts@1
-#     displayName: Publish Build Artifacts
-#     inputs:
-#       pathtoPublish: '$(Build.SourcesDirectory)/UNFLoader/UNFLoader'
-#       #pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#       artifactName: 'unfloader-macOS' 
-#       publishLocation: 'Container' # Options: container, filePath
-#       #targetPath: # Required when publishLocation == FilePath
-#       parallel: true # Optional
-#       #parallelCount: # Optional
+       echo Install D2XX drivers
+       curl -L https://ftdichip.com/wp-content/uploads/2021/01/D2XX1.4.22.zip --output macos_drivers.zip
+       unzip ./macos_drivers.zip
+
+       echo Attach drivers disk image
+       hdiutil attach ./D2XX1.4.22.dmg
+
+       echo Install drivers to installation location
+       sudo mkdir -p /usr/local/lib
+       sudo mkdir -p /usr/local/include
+       sudo cp /Volumes/release/D2XX/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.1.4.22.dylib
+       sudo ln -sf /usr/local/lib/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.dylib
+       sudo cp /Volumes/release/D2XX/ftd2xx.h /usr/local/include/ftd2xx.h
+       sudo cp /Volumes/release/D2XX/WinTypes.h /usr/local/include/WinTypes.h
+
+       echo Build macOS App
+       cd ./UNFLoader/
+       make
+       cd ..
+
+       echo Detatch drivers disk image
+       diskutil eject /Volumes/release
+     displayName: 'Build Program'
+   # Publish build artifacts to Azure Artifacts/TFS or a file share
+   - task: PublishBuildArtifacts@1
+     displayName: Publish Build Artifacts
+     inputs:
+       pathtoPublish: '$(Build.SourcesDirectory)/UNFLoader/UNFLoader'
+       #pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+       artifactName: 'unfloader-macOS' 
+       publishLocation: 'Container' # Options: container, filePath
+       #targetPath: # Required when publishLocation == FilePath
+       parallel: true # Optional
+       #parallelCount: # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,47 +139,47 @@ jobs:
     #releaseTag: # Required when compareWith == LastReleaseByTag
 
       
- - job: UFNLoader_macOS
-   pool:
+- job: UFNLoader_macOS
+  pool:
     vmImage: 'macOS-latest'
-   steps:
-   - script: |
-       echo Install helper package
-       curl -L https://www.ftdichip.com/old2020/Drivers/D2XX/MacOSX/D2xxHelper_v2.0.0.pkg --output helper.pkg
-       sudo installer -pkg ./helper.pkg -target /
+  steps:
+  - script: |
+      echo Install helper package
+      curl -L https://www.ftdichip.com/old2020/Drivers/D2XX/MacOSX/D2xxHelper_v2.0.0.pkg --output helper.pkg
+      sudo installer -pkg ./helper.pkg -target /
 
-       echo Install D2XX drivers
-       curl -L https://ftdichip.com/wp-content/uploads/2021/01/D2XX1.4.22.zip --output macos_drivers.zip
-       unzip ./macos_drivers.zip
+      echo Install D2XX drivers
+      curl -L https://ftdichip.com/wp-content/uploads/2021/01/D2XX1.4.22.zip --output macos_drivers.zip
+      unzip ./macos_drivers.zip
 
-       echo Attach drivers disk image
-       hdiutil attach ./D2XX1.4.22.dmg
+      echo Attach drivers disk image
+      hdiutil attach ./D2XX1.4.22.dmg
 
-       echo Install drivers to installation location
-       sudo mkdir -p /usr/local/lib
-       sudo mkdir -p /usr/local/include
-       sudo cp /Volumes/release/D2XX/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.1.4.22.dylib
-       sudo ln -sf /usr/local/lib/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.dylib
-       sudo cp /Volumes/release/D2XX/ftd2xx.h /usr/local/include/ftd2xx.h
-       sudo cp /Volumes/release/D2XX/WinTypes.h /usr/local/include/WinTypes.h
+      echo Install drivers to installation location
+      sudo mkdir -p /usr/local/lib
+      sudo mkdir -p /usr/local/include
+      sudo cp /Volumes/release/D2XX/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.1.4.22.dylib
+      sudo ln -sf /usr/local/lib/libftd2xx.1.4.22.dylib /usr/local/lib/libftd2xx.dylib
+      sudo cp /Volumes/release/D2XX/ftd2xx.h /usr/local/include/ftd2xx.h
+      sudo cp /Volumes/release/D2XX/WinTypes.h /usr/local/include/WinTypes.h
 
-       echo Build macOS App
-       cd ./UNFLoader/
-       make
-       cd ..
+      echo Build macOS App
+      cd ./UNFLoader/
+      make
+      cd ..
 
-       echo Detatch drivers disk image
-       diskutil eject /Volumes/release
-     displayName: 'Build Program'
-     continueOnError: false
-   # Publish build artifacts to Azure Artifacts/TFS or a file share
-   - task: PublishBuildArtifacts@1
-     displayName: Publish Build Artifacts
-     inputs:
-       pathtoPublish: '$(Build.SourcesDirectory)/UNFLoader/UNFLoader'
-       #pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-       artifactName: 'unfloader-macOS' 
-       publishLocation: 'Container' # Options: container, filePath
-       #targetPath: # Required when publishLocation == FilePath
-       parallel: true # Optional
-       #parallelCount: # Optional
+      echo Detatch drivers disk image
+      diskutil eject /Volumes/release
+    displayName: 'Build Program'
+    continueOnError: false
+  # Publish build artifacts to Azure Artifacts/TFS or a file share
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Build Artifacts
+    inputs:
+      pathtoPublish: '$(Build.SourcesDirectory)/UNFLoader/UNFLoader'
+      #pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'unfloader-macOS' 
+      publishLocation: 'Container' # Options: container, filePath
+      #targetPath: # Required when publishLocation == FilePath
+      parallel: true # Optional
+      #parallelCount: # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,7 @@ jobs:
        echo Detatch drivers disk image
        diskutil eject /Volumes/release
      displayName: 'Build Program'
+     continueOnError: false
    # Publish build artifacts to Azure Artifacts/TFS or a file share
    - task: PublishBuildArtifacts@1
      displayName: Publish Build Artifacts


### PR DESCRIPTION
This change is a first attempt at setting up an Azure Pipeline for N64-UNFLoader. I've followed the `UNFLoader_Linux` steps as a guideline for setting up the necessary dependencies and then installing it.

I'm unable to test the pipeline at the moment, but all of the steps worked on my MacBook Pro (non-retina, mid-2012) with macOS Catalina 10.15.7. I'd assume any Intel Mac should work the same. Not sure about Apple silicon though.

The pipeline stage does the following:
1. Downloads the driver helpers
2. Installs the driver helpers with the `installer` command
3. Downloads the D2XX drivers from the [FTDI website](https://ftdichip.com/drivers/d2xx-drivers/)
4. Unzips the D2XX drivers, showing a [DMG image](https://en.wikipedia.org/wiki/Apple_Disk_Image).
5. Mounts the `release` DMG image containing the drivers
6. Copies/symlinks the header and library files for the D2XX drivers to `/usr/local/lib` and `/usr/local/include`
7. Enters the `UNFLoader` directory, runs `make`, and leaves
8. Unmounts the `release` DMG image containing the drivers