### PR TITLE
Add sequence point to `++` operation in debug.cpp

### DIFF
--- a/UNFLoader/debug.cpp
+++ b/UNFLoader/debug.cpp
@@ -326,7 +326,8 @@ void debug_textinput(ftdi_context_t* cart, WINDOW* inputwin, char* buffer, u16* 
     pdprintw_nolog(inputwin, buffer, CRDEF_INPUT);
     
     // Draw the blinker
-    blinker = (blinker++) % (1+BLINKRATE * 2);
+    blinker++;
+    blinker = blinker % (1+BLINKRATE * 2);
     if (blinker >= BLINKRATE)
     {
         int x, y;


### PR DESCRIPTION
This is a bit of a nitpick change, but I figured I'd put up a PR to help keep the UNFLoader working on a variety of compilers and platforms.

I was compiling on macOS with default system version of `g++` (eg: Apple clang version 12.0.0 (clang-1200.0.32.29)). The compiler gave me the following warning in `debug.cpp`.
```bash
$ make
g++ -D LINUX -o UNFLoader main.cpp helper.cpp device.cpp debug.cpp device_64drive.cpp device_everdrive.cpp device_sc64.cpp Include/lodepng.cpp -lncurses -lftd2xx -lpthread -Wl,-rpath /usr/local/lib -L/usr/local/lib
debug.cpp:329:23: warning: multiple unsequenced modifications to 'blinker' [-Wunsequenced]
    blinker = (blinker++) % (1+BLINKRATE * 2);
            ~         ^
1 warning generated.
```

I doubt the lack of [sequence points](https://en.wikipedia.org/wiki/Sequence_point) for the ncurses blinker is going to cause critical [undefined behaviour](https://stackoverflow.com/a/949443), but I figured I'd update it just to minimize the chance it causes weird bugs down the line.

That said, I'm curious how other developers might feel about `-Wall -Werror` when it comes to adding new features. It'd be a little more legwork, but might help with keeping the source portable. That said, I understand if it's not something we want to take on at the moment.