### PR TITLE
64Drive/SummerCart64: Add C11 UB fix for va_start

### DIFF
--- a/UNFLoader/device_64drive.cpp
+++ b/UNFLoader/device_64drive.cpp
@@ -15,7 +15,7 @@ http://64drive.retroactive.be/support.php
         Function Prototypes
 *********************************/
 
-void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u8 numparams, ...);
+void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u32 numparams, ...);
 
 
 /*==============================
@@ -85,7 +85,7 @@ void device_open_64drive(ftdi_context_t* cart)
     @param The extra variadic commands to send
 ==============================*/
 
-void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u8 numparams, ...)
+void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u32 numparams, ...)
 {
     u8  send_buff[32];
     u32 recv_buff[32];

--- a/UNFLoader/device_sc64.cpp
+++ b/UNFLoader/device_sc64.cpp
@@ -29,7 +29,7 @@ https://github.com/Polprzewodnikowy/SummerCollection
 *********************************/
 
 static FT_STATUS device_read_manufacturer_sc64(ftdi_context_t* cart, int index, char* manufacturer);
-static void device_sendcmd_sc64(ftdi_context_t* cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u8 numparams, ...);
+static void device_sendcmd_sc64(ftdi_context_t* cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u32 numparams, ...);
 static void device_write_bank_sc64(ftdi_context_t* cart, u8 bank, u32 offset, u8* write_buffer, u32 write_length);
 
 
@@ -86,7 +86,7 @@ static FT_STATUS device_read_manufacturer_sc64(ftdi_context_t* cart, int index, 
     @param The extra variadic commands to send
 ==============================*/
 
-static void device_sendcmd_sc64(ftdi_context_t* cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u8 numparams, ...)
+static void device_sendcmd_sc64(ftdi_context_t* cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u32 numparams, ...)
 {
     va_list params;
     u8 cmd_params_buff[12];


### PR DESCRIPTION
When I compile `UNFLoader` on macOS with Apple Clang 12, I get the following compiler warnings

```
g++ -D LINUX -o UNFLoader main.cpp helper.cpp device.cpp debug.cpp device_64drive.cpp device_everdrive.cpp device_sc64.cpp Include/lodepng.cpp -lncurses -lftd2xx -lpthread -Wl,-rpath /usr/local/lib -L/usr/local/lib
device_64drive.cpp:93:22: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
    va_start(params, numparams);
                     ^
device_64drive.cpp:88:78: note: parameter of type 'u8' (aka 'unsigned char') is declared here
void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u8 numparams, ...)
                                                                             ^
1 warning generated.
device_sc64.cpp:108:22: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
    va_start(params, numparams);
                     ^
device_sc64.cpp:89:152: note: parameter of type 'u8' (aka 'unsigned char') is declared here
  ...cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u8 numparams, ...)
                                                                                                            ^
1 warning generated.
```

Looking at [some answers](https://stackoverflow.com/q/28054194) on [the internet](https://lkml.org/lkml/2018/10/10/55), it looks like variadic arguments that have their size promoted can be undefined behaviour in the C standard. I was able to resolve these warnings by changing `numparams` from `u8` to `u32`.
```c
void device_sendcmd_sc64(ftdi_context_t* cart, u8 command, u8* write_buffer, u32 write_length, u8* read_buffer, u32 read_length, bool reply, u32 numparams, ...);
// ...
void device_sendcmd_64drive(ftdi_context_t* cart, u8 command, bool reply, u32 numparams, ...);
```

This this might not be an immediate issue, but I can imagine ironing out UB might help with debugging later.

I'm unable to compile/run this with the appropriate flashcarts, so I'd be hesitant to merge without testing.