### PR TITLE
Add a timeout to usb_64drive_waitidle

### DIFF
--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -604,7 +604,7 @@ static s8 usb_64drive_wait()
         #endif
         
         // Took too long, abort
-        if((timeout++) > 1000000)
+        if((timeout++) > 10000)
             return -1;
     }
     while((ret >> 8) & D64_CI_BUSY);
@@ -642,9 +642,10 @@ static void usb_64drive_setwritable(u8 enable)
     Waits for the 64Drive's USB to be idle
 ==============================*/
 
-static void usb_64drive_waitidle()
+static int usb_64drive_waitidle()
 {
     u32 status __attribute__((aligned(8)));
+    u32 timeout = 0;
     do 
     {
         #ifdef LIBDRAGON
@@ -657,8 +658,11 @@ static void usb_64drive_waitidle()
             #endif
         #endif
         status = (status >> 4) & D64_USB_BUSY;
+        if (timeout++ > 128)
+            return 0;
     }
     while(status != D64_USB_IDLE);
+    return 1;
 }
 
 
@@ -724,7 +728,8 @@ static void usb_64drive_write(int datatype, const void* data, int size)
     int read = 0;
     
     // Spin until the write buffer is free and then set the cartridge to write mode
-    usb_64drive_waitidle();
+    if (!usb_64drive_waitidle())
+        return;
     usb_64drive_setwritable(TRUE);
     
     // Write data to SDRAM until we've finished
@@ -749,7 +754,11 @@ static void usb_64drive_write(int datatype, const void* data, int size)
         }
         
         // Spin until the write buffer is free
-        usb_64drive_waitidle();
+        if (!usb_64drive_waitidle())
+        {
+            usb_64drive_setwritable(FALSE);
+            return;
+        }
         
         // Set up DMA transfer between RDRAM and the PI
         #ifdef LIBDRAGON


### PR DESCRIPTION
This change allows the application on N64 not to block even if UNFLoader is stopped.

Since usb.c is being vendored into libdragon, this change is important to open up for different tools that have a different approach compared to UNFLoader. While UNFLoader is a all-in-one tool to upload + debug N64 application, one can imagine some simpler tool that simply connects to the USB streams to monitor logs sent with the same protocol (a log viewer). Such an application might be started and stopped at any time during the N64 application lifetime, and we don't want the application to break whenever the tool Is stopped.