### PR TITLE
Fix segmentation fault when loading ROM while flash drive OS is not running

### DIFF
--- a/UNFLoader/device_everdrive.cpp
+++ b/UNFLoader/device_everdrive.cpp
@@ -1,7 +1,7 @@
 /***************************************************************
                       device_everdrive.cpp
-                               
-Handles EverDrive USB communication. A lot of the code here 
+
+Handles EverDrive USB communication. A lot of the code here
 is courtesy of KRIKzz's USB tool:
 http://krikzz.com/pub/support/everdrive-64/x-series/dev/
 ***************************************************************/
@@ -26,17 +26,17 @@ bool device_test_everdrive(ftdi_context_t* cart, int index)
         char send_buff[16];
         char recv_buff[16];
         memset(send_buff, 0, 16);
-        memset(recv_buff, 0, 16);  
+        memset(recv_buff, 0, 16);
 
         // Define the command to send
         send_buff[0] = 'c';
         send_buff[1] = 'm';
         send_buff[2] = 'd';
-        send_buff[3] = 't'; 
+        send_buff[3] = 't';
 
         // Open the device
         cart->status = FT_Open(index, &cart->handle);
-        if (cart->status != FT_OK || !cart->handle) 
+        if (cart->status != FT_OK || !cart->handle)
         {
             free(cart->dev_info);
             terminate("Could not open device.");
@@ -51,6 +51,7 @@ bool device_test_everdrive(ftdi_context_t* cart, int index)
         testcommand(FT_Write(cart->handle, send_buff, 16, &cart->bytes_written), "Unable to write to flashcart.");
         testcommand(FT_Read(cart->handle, recv_buff, 16, &cart->bytes_read), "Unable to read from flashcart.");
         testcommand(FT_Close(cart->handle), "Unable to close flashcart.");
+        cart->handle = 0;
 
         // Check if the EverDrive responded correctly
         return recv_buff[3] == 'r';
@@ -100,7 +101,7 @@ void device_sendcmd_everdrive(ftdi_context_t* cart, char command, int address, i
     // Define the command and send it
     cmd_buffer[0] = 'c';
     cmd_buffer[1] = 'm';
-    cmd_buffer[2] = 'd'; 
+    cmd_buffer[2] = 'd';
     cmd_buffer[3] = command;
     cmd_buffer[4] = (char) (address >> 24);
     cmd_buffer[5] = (char) (address >> 16);
@@ -173,13 +174,13 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
         int i;
 
         // Decide how many bytes to send
-		if (bytes_left >= 0x8000) 
+		if (bytes_left >= 0x8000)
 			bytes_do = 0x8000;
 		else
 			bytes_do = bytes_left;
 
         // End if we've got nothing else to send
-		if (bytes_do <= 0) 
+		if (bytes_do <= 0)
             break;
 
         // Try to send chunks
@@ -188,7 +189,7 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
             int j;
 
             // If we failed the first time, clear the USB and try again
-			if (i == 1) 
+			if (i == 1)
             {
 				FT_ResetPort(cart->handle);
 				FT_ResetDevice(cart->handle);
@@ -222,12 +223,12 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
 			FT_Write(cart->handle, rom_buffer, bytes_do, &cart->bytes_written);
 
             // If we managed to write, don't try again
-			if (cart->bytes_written) 
+			if (cart->bytes_written)
                 break;
 		}
 
         // Check for a timeout
-		if (cart->bytes_written == 0) 
+		if (cart->bytes_written == 0)
             terminate("Everdrive timed out.");
 
          // Keep track of how many bytes were uploaded
@@ -267,10 +268,10 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
         }
         if (extension == -1)
             extension = len;
-        memcpy(filename, global_filename+i, (extension-i)); 
+        memcpy(filename, global_filename+i, (extension-i));
         FT_Write(cart->handle, filename, 256, &cart->bytes_written);
     }
-    
+
     // Print that we've finished
     pdprint_replace("ROM successfully uploaded in %.2f seconds!\n", CRDEF_PROGRAM, ((double)(clock()-upload_time))/CLOCKS_PER_SEC);
     free(rom_buffer);
@@ -314,20 +315,20 @@ void device_senddata_everdrive(ftdi_context_t* cart, int datatype, char* data, u
         int i, block;
 
         // Decide how many bytes to send
-		if (left >= 512) 
+		if (left >= 512)
 			block = 512;
 		else
 			block = left;
 
         // End if we've got nothing else to send
-		if (block <= 0) 
+		if (block <= 0)
             break;
 
         // Try to send chunks
 		for (i=0; i<2; i++)
         {
             // If we failed the first time, clear the USB and try again
-			if (i == 1) 
+			if (i == 1)
             {
 				FT_ResetPort(cart->handle);
 				FT_ResetDevice(cart->handle);
@@ -344,7 +345,7 @@ void device_senddata_everdrive(ftdi_context_t* cart, int datatype, char* data, u
 		}
 
         // Check for a timeout
-		if (cart->bytes_written == 0) 
+		if (cart->bytes_written == 0)
             terminate("Everdrive timed out.");
 
         // Draw the progress bar
@@ -373,4 +374,5 @@ void device_senddata_everdrive(ftdi_context_t* cart, int datatype, char* data, u
 void device_close_everdrive(ftdi_context_t* cart)
 {
     testcommand(FT_Close(cart->handle), "Unable to close flashcart.");
+    cart->handle = 0;
 }

--- a/UNFLoader/device_everdrive.cpp
+++ b/UNFLoader/device_everdrive.cpp
@@ -132,9 +132,9 @@ void device_sendcmd_everdrive(ftdi_context_t* cart, char command, int address, i
 
 void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
 {
-	int	   bytes_done = 0;
+    int	   bytes_done = 0;
     int	   bytes_left;
-	int	   bytes_do;
+    int	   bytes_do;
     char*  rom_buffer = (char*) malloc(sizeof(int) * 32*1024);
     int    crc_area = 0x100000 + 4096;
     time_t upload_time = clock();
@@ -174,27 +174,27 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
         int i;
 
         // Decide how many bytes to send
-		if (bytes_left >= 0x8000)
-			bytes_do = 0x8000;
-		else
-			bytes_do = bytes_left;
+        if (bytes_left >= 0x8000)
+            bytes_do = 0x8000;
+        else
+            bytes_do = bytes_left;
 
         // End if we've got nothing else to send
-		if (bytes_do <= 0)
+        if (bytes_do <= 0)
             break;
 
         // Try to send chunks
-		for (i=0; i<2; i++)
+        for (i=0; i<2; i++)
         {
             int j;
 
             // If we failed the first time, clear the USB and try again
-			if (i == 1)
+            if (i == 1)
             {
-				FT_ResetPort(cart->handle);
-				FT_ResetDevice(cart->handle);
-				FT_Purge(cart->handle, FT_PURGE_RX | FT_PURGE_TX);
-			}
+                FT_ResetPort(cart->handle);
+                FT_ResetDevice(cart->handle);
+                FT_Purge(cart->handle, FT_PURGE_RX | FT_PURGE_TX);
+            }
 
             // Read the ROM to the buffer and byteswap it if needed
             fread(rom_buffer, bytes_do, 1, file);
@@ -220,23 +220,23 @@ void device_sendrom_everdrive(ftdi_context_t* cart, FILE *file, u32 size)
 
             // Send the chunk to RAM. If we reached EOF it doesn't matter what we send
             // TODO: Send 0's when EOF is reached
-			FT_Write(cart->handle, rom_buffer, bytes_do, &cart->bytes_written);
+            FT_Write(cart->handle, rom_buffer, bytes_do, &cart->bytes_written);
 
             // If we managed to write, don't try again
-			if (cart->bytes_written)
+            if (cart->bytes_written)
                 break;
-		}
+        }
 
         // Check for a timeout
-		if (cart->bytes_written == 0)
+        if (cart->bytes_written == 0)
             terminate("Everdrive timed out.");
 
          // Keep track of how many bytes were uploaded
-		bytes_left -= bytes_do;
-		bytes_done += bytes_do;
+        bytes_left -= bytes_do;
+        bytes_done += bytes_do;
 
-		// Draw the progress bar
-		progressbar_draw("Uploading ROM", CRDEF_PROGRAM, (float)bytes_done/size);
+        // Draw the progress bar
+        progressbar_draw("Uploading ROM", CRDEF_PROGRAM, (float)bytes_done/size);
     }
 
     // Send the PIFboot command
@@ -315,45 +315,45 @@ void device_senddata_everdrive(ftdi_context_t* cart, int datatype, char* data, u
         int i, block;
 
         // Decide how many bytes to send
-		if (left >= 512)
-			block = 512;
-		else
-			block = left;
+        if (left >= 512)
+          block = 512;
+        else
+          block = left;
 
         // End if we've got nothing else to send
-		if (block <= 0)
+        if (block <= 0)
             break;
 
         // Try to send chunks
-		for (i=0; i<2; i++)
+        for (i=0; i<2; i++)
         {
-            // If we failed the first time, clear the USB and try again
-			if (i == 1)
+                // If we failed the first time, clear the USB and try again
+            if (i == 1)
             {
-				FT_ResetPort(cart->handle);
-				FT_ResetDevice(cart->handle);
-				FT_Purge(cart->handle, FT_PURGE_RX | FT_PURGE_TX);
-			}
+                FT_ResetPort(cart->handle);
+                FT_ResetDevice(cart->handle);
+                FT_Purge(cart->handle, FT_PURGE_RX | FT_PURGE_TX);
+            }
 
-			// Send the chunk through USB
-			memcpy(buffer, data+read, block);
-			FT_Write(cart->handle, buffer, 512, &cart->bytes_written);
+            // Send the chunk through USB
+            memcpy(buffer, data+read, block);
+            FT_Write(cart->handle, buffer, 512, &cart->bytes_written);
 
-            // If we managed to write, don't try again
-			if (cart->bytes_written)
+                  // If we managed to write, don't try again
+            if (cart->bytes_written)
                 break;
-		}
+        }
 
         // Check for a timeout
-		if (cart->bytes_written == 0)
+        if (cart->bytes_written == 0)
             terminate("Everdrive timed out.");
 
         // Draw the progress bar
         progressbar_draw("Uploading data", CRDEF_INFO, (float)read/size);
 
         // Keep track of how many bytes were uploaded
-		left -= block;
-		read += block;
+        left -= block;
+        read += block;
     }
 
     // Send the CMP signal

--- a/UNFLoader/device_sc64.cpp
+++ b/UNFLoader/device_sc64.cpp
@@ -427,10 +427,10 @@ void device_senddata_sc64(ftdi_context_t* cart, int datatype, char* data, u32 si
     for (int i = 0; i < num_transfers; i++) {
         // Calculate block length
         u32 block_length = MIN(transfer_length, DEV_MAX_RW_BYTES);
-        
+
         // Send block
         device_sendcmd_sc64(cart, DEV_CMD_DEBUG_WRITE, buff_ptr, block_length, NULL, 0, false, 1, DEV_DEBUG_WRITE_PARAM_1(block_length));
-        
+
         // Update tracking variables
         transfer_length -= block_length;
         buff_ptr += block_length;
@@ -450,4 +450,5 @@ void device_senddata_sc64(ftdi_context_t* cart, int datatype, char* data, u32 si
 void device_close_sc64(ftdi_context_t* cart)
 {
     testcommand(FT_Close(cart->handle), "Error: Unable to close flashcart.\n");
+    cart->handle = 0;
 }


### PR DESCRIPTION
I noticed that if I tried to load a ROM with UNFLoader when the EverDrive OS was not running, I would get a Segmentation Fault: 
```
UNFLoader
--------------------------------------------
Cobbled together by Buu342
Compiled on Mar  1 2021

Debug mode enabled.
Attempting flashcart autodetection.
Error: No flashcart detected. Are you running sudo?

Segmentation fault: 11
```

This PR attempts to fix that, by setting the cart handle to zero whenever `FT_Close` is called.

The PR also includes whitespace corrections for the files that are touched. I'm happy to remove those if you think that they are too much of a distraction from the salient changes in this PR.