### PR TITLE
Memory alignment fix for usb_everdrive_writereg

### DIFF
--- a/Examples/Libultra/1. Hello World/usb.c
+++ b/Examples/Libultra/1. Hello World/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(8))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 

--- a/Examples/Libultra/2. Thread Faults/usb.c
+++ b/Examples/Libultra/2. Thread Faults/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(8))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 

--- a/Examples/Libultra/3. USB Read/usb.c
+++ b/Examples/Libultra/3. USB Read/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(8))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 

--- a/Examples/Libultra/4. Command Interpreter/usb.c
+++ b/Examples/Libultra/4. Command Interpreter/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(8))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 

--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(8))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 


### PR DESCRIPTION
As discussed in https://github.com/buu342/N64-UNFLoader/issues/63

While diffing each copy of usb.c, I noticed that D64_POLLTIME was different for example 3. I've changed that to be consistent with the primary copy of `USB+Debug Library/usb.c` but I can change that back if it was different for a reason.