### PR TITLE
Align Everdrive reads/writes to 16 byte boundaries

### DIFF
--- a/Examples/Libdragon/1. Hello World/usb.c
+++ b/Examples/Libdragon/1. Hello World/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(16))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 
@@ -1082,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1099,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libdragon/1. Hello World/usb.c
+++ b/Examples/Libdragon/1. Hello World/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libdragon/1. Hello World/usb.c
+++ b/Examples/Libdragon/1. Hello World/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libdragon/1. Hello World/usb.c
+++ b/Examples/Libdragon/1. Hello World/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libdragon/2. USB Read/usb.c
+++ b/Examples/Libdragon/2. USB Read/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(16))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 
@@ -1082,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1099,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libdragon/2. USB Read/usb.c
+++ b/Examples/Libdragon/2. USB Read/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libdragon/2. USB Read/usb.c
+++ b/Examples/Libdragon/2. USB Read/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libdragon/2. USB Read/usb.c
+++ b/Examples/Libdragon/2. USB Read/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libdragon/3. Command Interpreter/usb.c
+++ b/Examples/Libdragon/3. Command Interpreter/usb.c
@@ -1071,7 +1071,8 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    usb_everdrive_writedata(&value, ED_GET_REGADD(reg), sizeof(u32));
+    u32 val __attribute__((aligned(16))) = value;
+    usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
 
@@ -1082,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1099,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libdragon/3. Command Interpreter/usb.c
+++ b/Examples/Libdragon/3. Command Interpreter/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libdragon/3. Command Interpreter/usb.c
+++ b/Examples/Libdragon/3. Command Interpreter/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libdragon/3. Command Interpreter/usb.c
+++ b/Examples/Libdragon/3. Command Interpreter/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libultra/1. Hello World/usb.c
+++ b/Examples/Libultra/1. Hello World/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libultra/1. Hello World/usb.c
+++ b/Examples/Libultra/1. Hello World/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libultra/1. Hello World/usb.c
+++ b/Examples/Libultra/1. Hello World/usb.c
@@ -1071,7 +1071,7 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    u32 val __attribute__((aligned(8))) = value;
+    u32 val __attribute__((aligned(16))) = value;
     usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
@@ -1083,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1100,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libultra/1. Hello World/usb.c
+++ b/Examples/Libultra/1. Hello World/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libultra/2. Thread Faults/usb.c
+++ b/Examples/Libultra/2. Thread Faults/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libultra/2. Thread Faults/usb.c
+++ b/Examples/Libultra/2. Thread Faults/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libultra/2. Thread Faults/usb.c
+++ b/Examples/Libultra/2. Thread Faults/usb.c
@@ -1071,7 +1071,7 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    u32 val __attribute__((aligned(8))) = value;
+    u32 val __attribute__((aligned(16))) = value;
     usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
@@ -1083,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1100,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libultra/2. Thread Faults/usb.c
+++ b/Examples/Libultra/2. Thread Faults/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libultra/3. USB Read/usb.c
+++ b/Examples/Libultra/3. USB Read/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libultra/3. USB Read/usb.c
+++ b/Examples/Libultra/3. USB Read/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libultra/3. USB Read/usb.c
+++ b/Examples/Libultra/3. USB Read/usb.c
@@ -1071,7 +1071,7 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    u32 val __attribute__((aligned(8))) = value;
+    u32 val __attribute__((aligned(16))) = value;
     usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
@@ -1083,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1100,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libultra/3. USB Read/usb.c
+++ b/Examples/Libultra/3. USB Read/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/Examples/Libultra/4. Command Interpreter/usb.c
+++ b/Examples/Libultra/4. Command Interpreter/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/Examples/Libultra/4. Command Interpreter/usb.c
+++ b/Examples/Libultra/4. Command Interpreter/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/Examples/Libultra/4. Command Interpreter/usb.c
+++ b/Examples/Libultra/4. Command Interpreter/usb.c
@@ -1071,7 +1071,7 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    u32 val __attribute__((aligned(8))) = value;
+    u32 val __attribute__((aligned(16))) = value;
     usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
@@ -1083,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1100,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/Examples/Libultra/4. Command Interpreter/usb.c
+++ b/Examples/Libultra/4. Command Interpreter/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     

--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -814,8 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(16)));
-    ret = usb_64drive_armstatus();
+    u32 ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
     {

--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(16)));
+    u32 status;
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);

--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -1071,7 +1071,7 @@ static void usb_everdrive_writedata(void* buff, u32 pi_address, u32 len)
 
 static void usb_everdrive_writereg(u64 reg, u32 value) 
 {
-    u32 val __attribute__((aligned(8))) = value;
+    u32 val __attribute__((aligned(16))) = value;
     usb_everdrive_writedata(&val, ED_GET_REGADD(reg), sizeof(u32));
 }
 
@@ -1083,7 +1083,7 @@ static void usb_everdrive_writereg(u64 reg, u32 value)
 
 static void usb_everdrive_usbbusy() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     do 
     {
         usb_everdrive_readreg(ED_REG_USBCFG, &val);
@@ -1100,7 +1100,7 @@ static void usb_everdrive_usbbusy()
 
 static u8 usb_everdrive_canread() 
 {
-    u32 val __attribute__((aligned(8)));
+    u32 val __attribute__((aligned(16)));
     u32 status = ED_USBSTAT_POWER;
     
     // Read the USB register and check its status

--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -344,7 +344,7 @@ char usb_initialize()
 
 static void usb_findcart()
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     
     // Read the cartridge and check if we have a 64Drive.
     #ifdef LIBDRAGON
@@ -587,7 +587,7 @@ void usb_purge()
 
 static s8 usb_64drive_wait()
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     u32 timeout = 0; // I wanted to use osGetTime() but that requires the VI manager
     
     // Wait until the cartridge interface is ready
@@ -644,7 +644,7 @@ static void usb_64drive_setwritable(u8 enable)
 
 static int usb_64drive_waitidle()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     u32 timeout = 0;
     do 
     {
@@ -674,7 +674,7 @@ static int usb_64drive_waitidle()
 
 static u32 usb_64drive_armstatus()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     #ifdef LIBDRAGON
         status = io_read(D64_CIBASE_ADDRESS + D64_REGISTER_USBCOMSTAT);
     #else
@@ -695,7 +695,7 @@ static u32 usb_64drive_armstatus()
 
 static void usb_64drive_waitdisarmed()
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         #ifdef LIBDRAGON
@@ -814,7 +814,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
 static void usb_64drive_arm(u32 offset, u32 size)
 {
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     ret = usb_64drive_armstatus();
     
     if (ret != D64_USB_ARMING && ret != D64_USB_ARMED)
@@ -872,7 +872,7 @@ static void usb_64drive_disarm()
 static u32 usb_64drive_poll()
 {
     int i;
-    u32 ret __attribute__((aligned(8)));
+    u32 ret __attribute__((aligned(16)));
     
     // Arm the USB buffer
     usb_64drive_waitidle();
@@ -955,7 +955,7 @@ static void usb_64drive_read()
 
 static void usb_everdrive_wait_pidma() 
 {
-    u32 status __attribute__((aligned(8)));
+    u32 status __attribute__((aligned(16)));
     do
     {
         status = *(volatile unsigned long *)(N64_PI_ADDRESS + N64_PI_STATUS);
@@ -1222,7 +1222,7 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll()
 {
-    char buff[16] __attribute__((aligned(8)));
+    char buff[16] __attribute__((aligned(16)));
     int len;
     int offset = 0;
     
@@ -1324,7 +1324,7 @@ static void usb_everdrive_read()
 
 static u32 usb_sc64_read_usb_scr(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         usb_scr = io_read(SC64_REG_USB_SCR);
@@ -1347,7 +1347,7 @@ static u32 usb_sc64_read_usb_scr(void)
 
 static u32 usb_sc64_read_usb_fifo(void)
 {
-    u32 data __attribute__((aligned(8)));
+    u32 data __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         data = io_read(SC64_MEM_USB_FIFO_BASE);
@@ -1371,7 +1371,7 @@ static u32 usb_sc64_read_usb_fifo(void)
 
 static s8 usb_sc64_waitidle(void)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
 
     do
     {
@@ -1396,7 +1396,7 @@ static s8 usb_sc64_waitidle(void)
 
 static s32 usb_sc64_waitdata(u32 length)
 {
-    u32 usb_scr __attribute__((aligned(8)));
+    u32 usb_scr __attribute__((aligned(16)));
     u32 wait_length = ALIGN(MIN(length, SC64_MEM_USB_FIFO_LEN), 4);
     u32 bytes = 0;
 
@@ -1423,7 +1423,7 @@ static s32 usb_sc64_waitdata(u32 length)
 
 static void usb_sc64_setwritable(u8 enable)
 {
-    u32 scr __attribute__((aligned(8)));
+    u32 scr __attribute__((aligned(16)));
 
     #ifdef LIBDRAGON
         scr = io_read(SC64_REG_SCR);
@@ -1584,7 +1584,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
 
 static u32 usb_sc64_poll(void)
 {
-    u32 buff __attribute__((aligned(8)));
+    u32 buff __attribute__((aligned(16)));
     u32 sdram_address;
     int left;
     


### PR DESCRIPTION
Hello again! After my earlier changes to resolve memory alignment issues, I noticed that on very rare occasions, my code would crash in similar ways. After a lot of trial and error, I found three cases where DMA reads/writes needed to be aligned to 16-byte boundaries rather than 8-bytes. I don't entirely understand why this was necessary, but I have found N64 documentation that recommends doing this.

From http://n64devkit.square7.ch/n64man/os/osPiStartDma.htm:
> The PI device address (devAddr) must be 2-byte aligned. The RDRAM virtual address (vAddr) must be 8-byte aligned, but for OS_READ DMA operations, a stricter alignment is recommended. See OS_DCACHE_ROUNDUP_ADDR for a description of the problems that can occur when transfers are not an integral number of cache lines.

I followed that to the documentation for `OS_DCACHE_ROUNDUP_ADDR` at http://n64devkit.square7.ch/n64man/os/OS_DCACHE_ROUNDUP_ADDR.htm and this note stood out:
> If the affected memory region is not cache-aligned, there exists the possibility that a CPU program variable also shares the data-cache line. During normal operation of the CPU cache, the data cache line can be written back and overwrite the data written by the external agent.

My interpretation of this is that is possible for a DMA read to overwrite data that the CPU may still attempt to access.

If this is correct, then it may be a good idea to replace all usages of `aligned(8)` to `aligned(16)` when those memory locations are going to be used for DMA reads/writes, not just those that I've changed here. If that makes sense to you, I'd be happy to tack those changes onto this PR.