### PR TITLE
Fix DATATYPE_TEXT handling for unterminated strings

### DIFF
--- a/UNFLoader/debug.cpp
+++ b/UNFLoader/debug.cpp
@@ -546,14 +546,15 @@ void debug_handle_text(ftdi_context_t* cart, u32 size, char* buffer, u32* read)
     int left = size;
 
     // Ensure the data fits within our buffer
-    if (left > BUFFER_SIZE)
-        left = BUFFER_SIZE;
+    if (left > BUFFER_SIZE-1)
+        left = BUFFER_SIZE-1;
 
     // Read bytes until we finished
     while (left != 0)
     {
         // Read from the USB and print it
         FT_Read(cart->handle, buffer, left, &cart->bytes_read);
+        buffer[cart->bytes_read] = '\0';
         pdprint("%s", CRDEF_PRINT, buffer);
 
         // Store the amount of bytes read
@@ -562,8 +563,8 @@ void debug_handle_text(ftdi_context_t* cart, u32 size, char* buffer, u32* read)
 
         // Ensure the data fits within our buffer
         left = size - total;
-        if (left > BUFFER_SIZE)
-            left = BUFFER_SIZE;
+        if (left > BUFFER_SIZE-1)
+            left = BUFFER_SIZE-1;
     }
 }
 


### PR DESCRIPTION
In general, DATATYPE_TEXT (like all USB messages) contains an explicit length in bytes of its content. The code in debug_handle_text was reading it but processing it like it was always zero terminated. Libdragon instead does not zero-terminate the strings because it relies on the explicit length to convey the termination.

With this PR, we standardize the libdragon interpretation of the protocol, and we make UNFLoader process correctly also non-zero-terminated strings. This also fixes a bug where strings longer than 512 bytes where being printed as corrupted by the UNFLoader because it didn't correctly terminate each intermediate 512 bytes read that was being performed.