### PR TITLE
Fix DATATYPE_TEXT handling for unterminated strings

### DIFF
--- a/UNFLoader/debug.cpp
+++ b/UNFLoader/debug.cpp
@@ -554,7 +554,7 @@ void debug_handle_text(ftdi_context_t* cart, u32 size, char* buffer, u32* read)
     {
         // Read from the USB and print it
         FT_Read(cart->handle, buffer, left, &cart->bytes_read);
-        pdprint("%s", CRDEF_PRINT, buffer);
+        pdprint("%.*s", CRDEF_PRINT, cart->bytes_read, buffer);
 
         // Store the amount of bytes read
         (*read) += cart->bytes_read;


### PR DESCRIPTION
In general, DATATYPE_TEXT (like all USB messages) contains an explicit length in bytes of its content. The code in debug_handle_text was reading it but processing it like it was always zero terminated. Libdragon instead does not zero-terminate the strings because it relies on the explicit length to convey the termination.

With this PR, we standardize the libdragon interpretation of the protocol, and we make UNFLoader process correctly also non-zero-terminated strings. This also fixes a bug where strings longer than 512 bytes where being printed as corrupted by the UNFLoader because it didn't correctly terminate each intermediate 512 bytes read that was being performed.

Fixes #53 