### PR TITLE
Refactor makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ FodyWeavers.xsd
 UNFLoader/ed stuff/
 UNFLoader/Dependencies/
 UNFLoader/UNFLoader
+
+*.o

--- a/UNFLoader/Makefile
+++ b/UNFLoader/Makefile
@@ -5,9 +5,11 @@ CODEFILES=main.cpp helper.cpp device.cpp debug.cpp \
 	device_64drive.cpp \
 	device_everdrive.cpp \
 	device_sc64.cpp
+CODEOBJECTS =	$(CODEFILES:.cpp=.o)
 LIBFILES=Include/lodepng.cpp
+LIBOBJECTS =	$(LIBFILES:.cpp=.o)
 
-CC=g++
+CXX=g++
 
 ifeq ($(OS_NAME),Darwin)
 	DEPENDENCIES := -lncurses -lftd2xx -lpthread
@@ -18,5 +20,25 @@ endif
 LINKER_OPTIONS := -Wl,-rpath /usr/local/lib
 CFLAGS=-D LINUX -D_XOPEN_SOURCE_EXTENDED
 
-default:
-	$(CC) $(CFLAGS) -o $(APP) $(CODEFILES) $(LIBFILES) $(DEPENDENCIES) $(LINKER_OPTIONS) -L/usr/local/lib
+default: $(APP)
+
+$(APP): $(CODEOBJECTS) $(LIBOBJECTS)
+	@echo "Linking $@"
+	@$(CXX) $(CFLAGS) -o $(APP) $(CODEOBJECTS) $(LIBOBJECTS) $(DEPENDENCIES) $(LINKER_OPTIONS) -L/usr/local/lib
+
+%.o: %.cpp
+	@echo "Compiling $<"
+	@$(CXX) -c $(CFLAGS) -o $@ $<
+
+clean:
+	@echo "Cleaning built artifacts.."
+	@rm -f $(APP) $(CODEOBJECTS) $(LIBOBJECTS)
+
+install: $(APP)
+	@echo "Installing $(APP) to /usr/local/bin"
+	@mkdir -p /usr/local/bin
+	@cp $(APP) /usr/local/bin/$(APP)
+
+uninstall: $(APP)
+	@echo "Removing $(APP) from /usr/local/bin"
+	@rm -f /usr/local/bin/$(APP)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40003130/149242778-5ed8266d-e034-4d92-9970-4376a49793e2.png)

This PR edits the Makefile for building UNFLoader under MacOS/Linux to be more "intelligent" in how it does things

Previously, the makefile would always rebuild the app by running g++ with every single code file at the same time, so all files would be recompiled regardless if any changes had actually been made to the codebase

Now, each codefile is built seperately, and linked together at the end to form the executable. Additonally, `clean`, `install`, and `uninstall` targets have been added.

`clean` deletes built artifacts like the app and object files.

`install` installs UNFLoader to `/usr/local/bin`, allowing it to be used system-wide.

`uninstall` will delete UNFLoader from `/usr/local/bin`, if it exists.