### PR TITLE
Fix writing to debug log file on some systems

### DIFF
--- a/UNFLoader/helper.cpp
+++ b/UNFLoader/helper.cpp
@@ -111,9 +111,13 @@ static void __pdprint_v(short color, const char* str, va_list args)
     int i;
     va_list args_debugout;
 
-    // If debug file exists, copy args to second va_list to reuse them later
+    // Print to the output debug file if it exists
     if (global_debugoutptr != NULL)
+    {
         va_copy(args_debugout, args);
+        vfprintf(global_debugoutptr, str, args_debugout);
+        va_end(args_debugout);
+    }
 
     // Disable all the colors
     for (i=0; i<TOTAL_COLORS; i++)
@@ -126,13 +130,6 @@ static void __pdprint_v(short color, const char* str, va_list args)
     // Print the string
     vw_printw(stdscr, str, args);
     refresh();
-
-    // Print to the output debug file if it exists
-    if (global_debugoutptr != NULL)
-    {
-        vfprintf(global_debugoutptr, str, args_debugout);
-        va_end(args_debugout);
-    }
 }
 
 

--- a/UNFLoader/helper.cpp
+++ b/UNFLoader/helper.cpp
@@ -42,10 +42,15 @@ void __pdprint(short color, const char* str, ...)
     vw_printw(stdscr, str, args);
     refresh();
 
+    va_end(args);
+
     // Print to the output debug file if it exists
     if (global_debugoutptr != NULL)
+    {
+        va_start(args, str);
         vfprintf(global_debugoutptr, str, args);
-    va_end(args);
+        va_end(args);
+    }
 }
 
 
@@ -81,10 +86,15 @@ void __pdprintw(WINDOW *win, short color, char log, const char* str, ...)
         wrefresh(win);
     }
 
+    va_end(args);
+
     // Print to the output debug file if it exists
     if (log && global_debugoutptr != NULL)
+    {
+        va_start(args, str);
         vfprintf(global_debugoutptr, str, args);
-    va_end(args);
+        va_end(args);
+    }
 }
 
 
@@ -99,6 +109,11 @@ void __pdprintw(WINDOW *win, short color, char log, const char* str, ...)
 static void __pdprint_v(short color, const char* str, va_list args)
 {
     int i;
+    va_list args_debugout;
+
+    // If debug file exists, copy args to second va_list to reuse them later
+    if (global_debugoutptr != NULL)
+        va_copy(args_debugout, args);
 
     // Disable all the colors
     for (i=0; i<TOTAL_COLORS; i++)
@@ -114,7 +129,10 @@ static void __pdprint_v(short color, const char* str, va_list args)
 
     // Print to the output debug file if it exists
     if (global_debugoutptr != NULL)
-        vfprintf(global_debugoutptr, str, args);
+    {
+        vfprintf(global_debugoutptr, str, args_debugout);
+        va_end(args_debugout);
+    }
 }
 
 
@@ -148,10 +166,15 @@ void __pdprint_replace(short color, const char* str, ...)
     vw_printw(stdscr, str, args);
     refresh();
 
+    va_end(args);
+
     // Print to the output debug file if it exists
     if (global_debugoutptr != NULL)
+    {
+        va_start(args, str);
         vfprintf(global_debugoutptr, str, args);
-    va_end(args);
+        va_end(args);
+    }
 }
 
 


### PR DESCRIPTION
This fixes the usage of variadic arguments in some functions in helper.cpp (for example __pdprint).

The `va_list` was forwarded to multiple functions (`vw_printw` and `vfprintf`), which is not actually allowed and only worked by chance on some implementations. On linux+gcc for example the debug log would get created, but nothing got written to it.
The solution is to call `va_start` multiple times (once for each usage), or copy the `va_list` with `va_copy`.