### PR TITLE
Fix `usb_everdrive_poll` for compilers using signed char

### DIFF
--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -1175,10 +1175,10 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll(void)
 {
-    int   len;
-    int   offset = 0;
-    char  buffaligned[32];
-    char* buff = (char*)OS_DCACHE_ROUNDUP_ADDR(buffaligned);
+    int len;
+    int offset = 0;
+    unsigned char  buffaligned[32];
+    unsigned char* buff = (unsigned char*)OS_DCACHE_ROUNDUP_ADDR(buffaligned);
     
     // Wait for the USB to be ready
     if (usb_everdrive_usbbusy())
@@ -1194,8 +1194,8 @@ static u32 usb_everdrive_poll(void)
         return 0;
         
     // Store information about the incoming data
-    usb_datatype = (int)buff[4];
-    usb_datasize = (int)buff[5]<<16 | (int)buff[6]<<8 | (int)buff[7]<<0;
+    usb_datatype = buff[4];
+    usb_datasize = (buff[5] << 16) | (buff[6] << 8) | (buff[7] << 0);
     usb_dataleft = usb_datasize;
     usb_readblock = -1;
     


### PR DESCRIPTION
## Description
Fixes `usb_everdrive_poll` so that it will always compute the correct packet size on compilers where the default signedness of `char` is signed, as is the case in the libdragon toolchain. See https://github.com/buu342/N64-UNFLoader/issues/112 for more specifics on why this doesn't work as-is.

## Related Issue
https://github.com/buu342/N64-UNFLoader/issues/112

## Motivation and Context
Sending packets of specific sizes over Everdrive USB to programs built with a compiler where `char` defaults to signed currently does not work. I ran into this while working on a project involving doing just that.

## How Has This Been Tested?
Previously, a packet of length 0x80 - 0xFF (inclusive) would appear to never arrive. After this change such packets arrive as expected.

## Screenshots (if appropriate):
