### PR TITLE
Fixup some things C wise, mostly incomplete prototypes and void* arithmetics

### DIFF
--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -26,7 +26,7 @@ https://github.com/buu342/N64-UNFLoader
 #define DEBUG_ADDRESS (0x04000000 - DEBUG_ADDRESS_SIZE) // Put the debug area at the 64MB - DEBUG_ADDRESS_SIZE area in ROM space
 
 // Data header related
-#define USBHEADER_CREATE(type, left) (((type<<24) | (left & 0x00FFFFFF)))
+#define USBHEADER_CREATE(type, left) ((((type)<<24) | ((left) & 0x00FFFFFF)))
 
 // Protocol related
 #define USBPROTOCOL_VERSION 2
@@ -233,8 +233,8 @@ static void usb_sc64_read(void);
 
 // Function pointers
 void (*funcPointer_write)(int datatype, const void* data, int size);
-u32  (*funcPointer_poll)();
-void (*funcPointer_read)();
+u32  (*funcPointer_poll)(void);
+void (*funcPointer_read)(void);
 
 // USB globals
 static s8 usb_cart = CART_NONE;
@@ -651,7 +651,7 @@ void usb_read(void* buffer, int nbytes)
         }
         
         // Copy from the USB buffer to the supplied buffer
-        memcpy(buffer+read, usb_buffer+copystart, block);
+        memcpy((void*)((uintptr_t)buffer+read), usb_buffer+copystart, block);
         
         // Increment/decrement all our counters
         read += block;
@@ -729,7 +729,7 @@ char usb_timedout()
     version.
 ==============================*/
 
-void usb_sendheartbeat()
+void usb_sendheartbeat(void)
 {
     u8 buffer[4];
 
@@ -951,7 +951,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
         usb_dma_write(usb_buffer, pi_address, ALIGN(block, 2));
 
         // Update pointers and variables
-        data += block;
+        data = (void*)((uintptr_t)data + block);
         left -= block;
         pi_address += block;
     }
@@ -1362,7 +1362,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
         usb_dma_write(usb_buffer, pi_address, ALIGN(block, 2));
 
         // Update pointers and variables
-        data += block;
+        data = (void*)((uintptr_t)data + block);
         left -= block;
         pi_address += block;
     }

--- a/USB+Debug Library/usb.h
+++ b/USB+Debug Library/usb.h
@@ -32,8 +32,8 @@
     *********************************/
     
     // Use these to conveniently read the header from usb_poll()
-    #define USBHEADER_GETTYPE(header) ((header & 0xFF000000) >> 24)
-    #define USBHEADER_GETSIZE(header) ((header & 0x00FFFFFF))
+    #define USBHEADER_GETTYPE(header) (((header) & 0xFF000000) >> 24)
+    #define USBHEADER_GETSIZE(header) (((header) & 0x00FFFFFF))
     
     
     /*********************************
@@ -46,7 +46,7 @@
         @return 1 if the USB initialization was successful, 0 if not
     ==============================*/
     
-    extern char usb_initialize();
+    extern char usb_initialize(void);
     
     
     /*==============================
@@ -55,7 +55,7 @@
         @return The CART macro that corresponds to the identified flashcart
     ==============================*/
     
-    extern char usb_getcart();
+    extern char usb_getcart(void);
     
     
     /*==============================
@@ -77,7 +77,7 @@
         @return The data header, or 0
     ==============================*/
     
-    extern unsigned long usb_poll();
+    extern unsigned long usb_poll(void);
     
     
     /*==============================
@@ -113,7 +113,7 @@
         Purges the incoming USB data
     ==============================*/
     
-    extern void usb_purge();
+    extern void usb_purge(void);
 
 
     /*==============================
@@ -122,7 +122,7 @@
         @return 1 if the USB timed out, 0 if not
     ==============================*/
 
-    extern char usb_timedout();
+    extern char usb_timedout(void);
 
 
     /*==============================
@@ -134,6 +134,6 @@
         version.
     ==============================*/
 
-    extern void usb_sendheartbeat();
+    extern void usb_sendheartbeat(void);
 
 #endif


### PR DESCRIPTION
## Description

### Incomplete prototypes
In C functions taking no arguments should look like `returntype func(void)`, whereas `returntype func()` is "arguments undefined"
A link for reference: https://stackoverflow.com/questions/51032/is-there-a-difference-between-foovoid-and-foo-in-c-or-c
-> fixed by `()` -> `(void)`

### `void*` arithmetics
As a gcc extension arithmetics on `void*` behave as if on `uint8_t*`.
But it's otherwise illegal in C (and does trip up the IDO compiler)
Link for reference: https://stackoverflow.com/questions/3523145/pointer-arithmetic-for-void-pointer-in-c
-> fixed by casts to `uintptr_t` and back to `void*` after the math

### Wrap macro arguments in parentheses
As a basic example:
Wrapped in parentheses: `#define MULT(a, b) ((a)*(b))`
Not wrapped: `#define MULT(a, b) (a*b)`
With the former: `MULT(1+2, 3) == 9` (`(1+2)*(3)`)
With the latter: `MULT(1+2, 3) == 7` (`1+2*3`)
Hence it is good practice to wrap used args in parentheses

### No empty line at end of files
Historically and maybe up to today it is expected that every line in a file ends with a line return
This may sound obvious but the last line in a file can technically not respect this
It sure causes issues with IDO so added a line break. It's also widely considered good practice

Link for reference: https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline
(TIL this is actually a POSIX thing)

## Related Issue
Please allow me to skip the step of creating issues since there's not much to document, but if you really want to I can create some.

## Motivation and Context
Make the code more solid/robust and conforming to C standards/best practices

## How Has This Been Tested?
The changes were prompted by trying to integrate this into the oot decomp, and the IDO compiler choking on various things. Eventually I got it to compile on IDO (though in the end in practice it didn't work but I was also working on a weird case)

I replaced libdragon's usb.c and usb.h with these files, built libdragon, and built a test rom from that. Works on hardware with the SC64 so no breakage apparently
(functionally there was no change)