### PR TITLE
Use the IPL2 checksum to decide which CIC to use.

### DIFF
--- a/UNFLoader/device.h
+++ b/UNFLoader/device.h
@@ -166,6 +166,7 @@
     uint32_t swap_endian(uint32_t val);
     uint32_t calc_padsize(uint32_t size);
     uint32_t romhash(byte* buff, uint32_t len);
-    CICType  cic_from_hash(uint32_t hash);
+    CICType  cic_from_bootcode(byte *bootcode);
+
 
 #endif

--- a/UNFLoader/device_64drive.cpp
+++ b/UNFLoader/device_64drive.cpp
@@ -191,7 +191,7 @@ bool device_explicitcic_64drive1(byte* bootcode)
 
 bool device_explicitcic_64drive2(byte* bootcode)
 {
-    device_setcic(cic_from_hash(romhash(bootcode, 4032)));
+    device_setcic(cic_from_bootcode(bootcode));
     return true;
 }
 

--- a/UNFLoader/device_sc64.cpp
+++ b/UNFLoader/device_sc64.cpp
@@ -448,7 +448,7 @@ uint32_t device_rompadding_sc64(uint32_t romsize)
 
 bool device_explicitcic_sc64(byte *bootcode)
 {
-    device_setcic(cic_from_hash(romhash(bootcode, 4032)));
+    device_setcic(cic_from_bootcode(bootcode));
     return true;
 }
 


### PR DESCRIPTION
This gracefully handles custom IPL3 bootcodes such as those that can be forked from libdragon's open source one.

NOTE: this is currently untested
