### PR TITLE
Add PREFIX variable to Makefile

### DIFF
--- a/UNFLoader/Makefile
+++ b/UNFLoader/Makefile
@@ -1,6 +1,8 @@
 APP=UNFLoader
 OS_NAME := $(shell uname -s)
 
+PREFIX ?= /usr/local
+
 CODEFILES = main.cpp helper.cpp term.cpp debug.cpp gdbstub.cpp
 CODEOBJECTS =	$(CODEFILES:.cpp=.o)
 LIBFILES = Include/lodepng.cpp
@@ -21,12 +23,12 @@ CXX = g++
 ifeq ($(OS_NAME),Darwin)
 	DEPENDENCIES := -lncurses -lpthread $(DEPENDENCIESLIB)
 else
-	DEPENDENCIESLIB += -l:libftdi1.a -l:libusb-1.0.a -ludev
+	DEPENDENCIESLIB += -lftdi1 -lusb-1.0 -ludev
 	DEPENDENCIESLIB_SHARED = -lftdi1 -lusb-1.0
 	DEPENDENCIES := -lncursesw -lpthread -lrt $(DEPENDENCIESLIB)
 endif
 
-CFLAGS = -D LINUX -D_XOPEN_SOURCE_EXTENDED -Wall -Wno-unknown-pragmas -O3 -std=c++11 -I /usr/local/include
+CFLAGS = -D LINUX -D_XOPEN_SOURCE_EXTENDED -Wall -Wno-unknown-pragmas -O3 -std=c++11 -I "$(PREFIX)/include"
 
 ifeq ($(OS_NAME),Darwin)
 	HOMEBREW_PREFIX=$(shell brew --prefix)
@@ -58,10 +60,10 @@ clean:
 	@rm -f $(APP) $(CODEOBJECTS) $(CARTLIBOBJECTS) $(LIBOBJECTS) $(CARTLIBNAME_STATIC) $(CARTLIBNAME_SHARED)
 
 install: $(APP)
-	@echo "Installing $(APP) to /usr/local/bin"
-	@mkdir -p /usr/local/bin
-	@cp $(APP) /usr/local/bin/$(APP)
+	@echo "Installing $(APP) to $(PREFIX)/bin"
+	@mkdir -p "$(PREFIX)/bin"
+	@cp "$(APP)" "$(PREFIX)/bin/$(APP)"
 
 uninstall: $(APP)
-	@echo "Removing $(APP) from /usr/local/bin"
-	@rm -f /usr/local/bin/$(APP)
+	@echo "Removing $(APP) from $(PREFIX)/bin"
+	@rm -f "$(PREFIX)/bin/$(APP)"


### PR DESCRIPTION
## Description
<!--- Provide a headline summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
This adds a new variable to the Makefile, `PREFIX`, that can be set (either by editing the file or by using `make install PREFIX="a filesystem location"`) to specify the include path and install location in place of `/usr/local`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the Makefile provides no way to specify an install location without manually editing every instance of the default path in the file. This allows setting install locations other than `/usr/local` directly in the CLI, which can be useful in contexts such as software packaging.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on EndeavourOS Linux. Head into the UNFLoader source directory and run the following commands:
```sh
$ make
$ sudo make install PREFIX=/usr
```
This should install the UNFLoader executable to `/usr/bin/UNFLoader`.