### PR TITLE
Remove shift left code from removebreakpoint

### DIFF
--- a/USB+Debug Library/debug.c
+++ b/USB+Debug Library/debug.c
@@ -2029,23 +2029,10 @@ https://github.com/buu342/N64-UNFLoader
                             data_cache_hit_writeback((u32*)addr, 4);
                             inst_cache_hit_invalidate((u32*)addr, 4);
                         #endif
-                    
-                    // Move all the breakpoints in front of it back
-                    for (i=index; i<BPOINT_COUNT; i++)
-                    {
-                        if (debug_bpoints[i].addr == NULL)
-                            break;
-                        if (i == BPOINT_COUNT-1)
-                        {
-                            debug_bpoints[i].addr = NULL;
-                            debug_bpoints[i].instruction = 0;
-                        }
-                        else
-                        {
-                            debug_bpoints[i].addr = debug_bpoints[i+1].addr;
-                            debug_bpoints[i].instruction = debug_bpoints[i+1].instruction;
-                        }
-                    }
+
+                    // free the breakpoint
+                    debug_bpoints[index].addr = NULL;
+                    debug_bpoints[index].instruction = 0;
                         
                     // Tell GDB we succeeded
                     usb_purge();


### PR DESCRIPTION
## Repro steps
 1. Add two breakpoints
 2. Remove two breakpoints

The second breakpoint will fail to be removed.

## Description
The second breakpoint is failing to be removed because the underlying instruction is still pointing the the old index (2), meanwhile the record in the table has shifted left.

The shift left is unnecessary, since addbreakpoint already scans the table. Can remove it entirely and fix the code.
