### PR TITLE
Exit with error status.

### DIFF
--- a/UNFLoader/helper.cpp
+++ b/UNFLoader/helper.cpp
@@ -96,7 +96,7 @@ void terminate(const char* reason, ...)
             WSACleanup();
         TerminateProcess(GetCurrentProcess(), 0);
     #else
-        exit(0);
+        exit(1);
     #endif
 }
 


### PR DESCRIPTION
When terminate is called, assume it's an error and exit with an appropriate termination state.

Otherwise it's not possible to use unfloader in a pipeline.