### PR TITLE
usb_findcart: correctly detect Everdrive X-cards without USB

### DIFF
--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -141,9 +141,9 @@ https://github.com/buu342/N64-UNFLoader
 
 #define ED_REGKEY         0xAA55
 
-#define ED25_VERSION      0xED640007
-#define ED3_VERSION       0xED640008
-#define ED7_VERSION       0xED640013
+#define ED25_VERSION      0xED640007        // V2.5
+#define ED3_VERSION       0xED640008        // V3
+#define EDX_VERSION       0xED640013        // X7, X5
 
 
 /*********************************
@@ -526,11 +526,16 @@ static void usb_findcart(void)
         return;
     
     // Check if we have an EverDrive
-    if (buff == ED7_VERSION || buff == ED3_VERSION)
+    if (buff == EDX_VERSION || buff == ED3_VERSION)
     {
         // Set the USB mode
         usb_io_write(ED_REG_SYSCFG, 0);
         usb_io_write(ED_REG_USBCFG, ED_USBMODE_RDNOP);
+
+        // If the USB unit is powered off, it means that this is a 
+        // X variant without USB support (X5).
+        if ((usb_io_read(ED_REG_USBCFG) & ED_USBSTAT_POWER) == 0)
+            return;
         
         // Set the cart to EverDrive
         usb_cart = CART_EVERDRIVE;


### PR DESCRIPTION
All X cards identify themselves as 0xED640013, but not all of them have a USB unit. This commit checks if the USB device reports to be powered, which seems to sufficient to detect the X5.