### PR TITLE
Thread synchronization for terminal, and debug communication

### DIFF
--- a/USB+Debug Library/usb.c
+++ b/USB+Debug Library/usb.c
@@ -371,7 +371,7 @@ static inline void usb_dma_write(void *ram_address, u32 pi_address, size_t size)
             osPiRawStartDma(OS_WRITE, pi_address, ram_address, size);
         #else
             osPiStartDma(&dmaIOMessageBuf, OS_MESG_PRI_NORMAL, OS_WRITE, pi_address, ram_address, size, &dmaMessageQ);
-            osRecvMesg(&dmaMessageQ, NULL, OS_MESG_BLOCK);
+            while (osRecvMesg(&dmaMessageQ, NULL, OS_MESG_NOBLOCK) != 0);
         #endif
     #else
         data_cache_hit_writeback(ram_address, size);


### PR DESCRIPTION
## Description

I came across some race conditions when trying this out with Libultra + EverDrive X7 (OS version 3.08).

I am trying to upload a ROM (~24 MB) to debug with GDB. Due to the ROM size, uploading can take some time. During this time, UNFLoader would sometimes crash (#130). On successful upload, GDB could rarely connect (#131).

**PC Side:**

* Multiple threads can read/modify the terminal `local_mesgqueue` at once
* Multiple threads can read/modify the debug `local_mesgqueue` at once

I was seeing crashes because of this, but it's possible for more subtle effects such as corrupt data. Fixed by protecting access using mutexes.

**Flashcart Side (Libultra Only):**

The debugger code relies on the USB thread having the highest priority so other threads don't interrupt it during reads/writes. However, it is possible for the USB thread to block in `usb_dma_write()` when waiting for the DMA to complete. During this time, another thread (such as the RDB thread) can call USB related functions and corrupt the internal state.

I was seeing invalid GDB responses (contents from multiple messages being sent back as one). Fixed with the same workaround as in `usb_dma_read()`: use a busy loop to wait for the DMA to complete. This could also be solved using `osSendMesg()` / `osRecvMesg()`.

## How Has This Been Tested?

Before these fixes, I could essentially never connect with GDB, and ROM uploads would fail ~25-30% of the time. With these fixes, I have not seen those problems once after many runs.

## Related Issues

#130
#131