### PR TITLE
Qsupported response

### DIFF
--- a/USB+Debug Library/debug.c
+++ b/USB+Debug Library/debug.c
@@ -1436,7 +1436,7 @@ https://github.com/buu342/N64-UNFLoader
         {
             sprintf(debug_buffer, "swbreak+");
             usb_purge();
-            usb_write(DATATYPE_RDBPACKET, debug_buffer, strlen(debug_buffer));
+            usb_write(DATATYPE_RDBPACKET, debug_buffer, strlen(debug_buffer)+1);
         }
         
         


### PR DESCRIPTION
## Description

In `debug.c`, `debug_rdb_qsupported()` [does not copy the null terminator](https://github.com/buu342/N64-UNFLoader/blob/725a07ae34b870fe04f6116c483cfb82ea87e8b1/USB%2BDebug%20Library/debug.c#L1439) to the response.

Depending on the previous buffer contents, sometimes everything is fine, but other times breakpoints don't work since GDB doesn't know the target supports software breakpoints (invalid qSupported response).

I noticed the other responses are null terminated so did the same here.

## How Has This Been Tested?

Without the fix, I observed the following warning in GDB:
```
warning: unrecognized item "swbreak+<garbage>" in "qSupported" response
```
(`<garbage>` depends on previous `debug_buffer` contents)

Sometimes everything was fine, other times I encountered the breakpoint issues mentioned above.

With the fix, there is no warning and I have not been able to reproduce the breakpoint issues.

## Related Issue
#131