### PR TITLE
Mask save type field when extracting data from the ED ROM header format

### DIFF
--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -679,7 +679,7 @@ static void autodetect_romheader()
     fseek(fp, 0, SEEK_SET);
 
     // If the savetype hasn't been forced
-    switch (buff[0x3F])
+    switch (buff[0x3F] & 0xF0)
     {
         case 0x10: device_setsave(SAVE_EEPROM4K); break;
         case 0x20: device_setsave(SAVE_EEPROM16K); break;


### PR DESCRIPTION
## Description
This commit fixes an issue where bits 0-3 in the "savetype" field in the ED header weren't discarded to determine the save type.
<!--- Provide a headline summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
none lol
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It fixes an annoying bug
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on the SummerCart64 with manually set savetype field in the hex editor.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
