### PR TITLE
fix: uses alternative method to open files on windows with shared permissions

### DIFF
--- a/UNFLoader/device.cpp
+++ b/UNFLoader/device.cpp
@@ -281,7 +281,12 @@ uint32_t device_rompadding(uint32_t romsize)
 bool device_explicitcic()
 {
     CICType oldcic = local_cart.cictype;
-    FILE* fp = fopen(local_rompath, "rb");
+    FILE* fp;
+    #ifndef LINUX
+    fp = _fsopen(local_rompath, "rb", _SH_DENYNO);
+    #else
+    fp = fopen(local_rompath, "rb");
+    #endif
     byte* bootcode = (byte*) malloc(4032);
 
     // Check fopen/malloc worked

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -487,7 +487,7 @@ static void program_loop()
                 // On windows, fopen will lock the file, so hot-reload features will not work.
                 // You have to use _fsopen and specify you want to allow shared access.
                 #ifndef LINUX
-                HANDLE file_handle = CreateFile(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
+                HANDLE file_handle = CreateFile(CA2CT(device_getrom()), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "r");
                 stream = std::ifstream(fp);

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -72,6 +72,10 @@ static std::list<char*>  local_args;
 static std::atomic<int>  local_esclevel (0);
 static std::atomic<bool> local_reupload (false);
 
+// Local funcs
+#ifndef LINUX
+wchar_t *convertCharArrayToLPCWSTR(const char* charArray);
+#endif
 
 /*==============================
     main
@@ -487,7 +491,7 @@ static void program_loop()
                 // On windows, fopen will lock the file, so hot-reload features will not work.
                 // You have to use _fsopen and specify you want to allow shared access.
                 #ifndef LINUX
-                HANDLE file_handle = CreateFile(CA2CT(device_getrom()), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
+                HANDLE file_handle = CreateFile(convertCharArrayToLPCWSTR(device_getrom()), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "r");
                 stream = std::ifstream(fp);
@@ -894,3 +898,12 @@ static void show_help()
     if (!term_isusingcurses())
         while ((category = getchar()) != '\n' && category != EOF);
 }
+
+#ifndef LINUX
+wchar_t *convertCharArrayToLPCWSTR(const char* charArray)
+{
+    wchar_t* wString=new wchar_t[4096];
+    MultiByteToWideChar(CP_ACP, 0, charArray, -1, wString, 4096);
+    return wString;
+}
+#endif

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -18,6 +18,12 @@ UNFLoader Entrypoint
 #include <thread>
 #include <chrono>
 
+
+// For _fsopen on windows
+#ifndef LINUX
+#include <share.h>
+#endif
+
 /*********************************
               Macros
 *********************************/

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -20,9 +20,9 @@ UNFLoader Entrypoint
 
 // For _fsopen on windows
 #ifndef LINUX
+#include <fstream>
 #include <share.h>
 #include <windows.h>
-#include <fstream.h>
 #endif
 
 /*********************************

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -24,6 +24,7 @@ UNFLoader Entrypoint
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
+#include <string>
 #endif
 
 /*********************************
@@ -486,7 +487,10 @@ static void program_loop()
                 // On windows, fopen will lock the file, so hot-reload features will not work.
                 // You have to use _fsopen and specify you want to allow shared access.
                 #ifndef LINUX
-                file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                const char* fileName = device_getrom();
+                size_t length = strlen(fileName);
+                std::wstring text_wchar(length, L'#');
+                file_handle = CreateFileA( mbstowcs(&text_wchar[0], fileName , length), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "rb");
                 #else

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -73,9 +73,9 @@ static std::atomic<int>  local_esclevel (0);
 static std::atomic<bool> local_reupload (false);
 
 // Local funcs
-#ifndef LINUX
-wchar_t *convertCharArrayToLPCWSTR(const char* charArray);
-#endif
+//#ifndef LINUX
+//wchar_t *convertCharArrayToLPCWSTR(const char* charArray);
+//#endif
 
 /*==============================
     main
@@ -491,7 +491,7 @@ static void program_loop()
                 // On windows, fopen will lock the file, so hot-reload features will not work.
                 // You have to use _fsopen and specify you want to allow shared access.
                 #ifndef LINUX
-                HANDLE file_handle = CreateFile(convertCharArrayToLPCWSTR(device_getrom()), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
+                HANDLE file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "r");
                 stream = std::ifstream(fp);
@@ -899,11 +899,11 @@ static void show_help()
         while ((category = getchar()) != '\n' && category != EOF);
 }
 
-#ifndef LINUX
-wchar_t *convertCharArrayToLPCWSTR(const char* charArray)
-{
-    wchar_t* wString=new wchar_t[4096];
-    MultiByteToWideChar(CP_ACP, 0, charArray, -1, wString, 4096);
-    return wString;
-}
-#endif
+//#ifndef LINUX
+//wchar_t *convertCharArrayToLPCWSTR(const char* charArray)
+//{
+//    wchar_t* wString=new wchar_t[4096];
+//    MultiByteToWideChar(CP_ACP, 0, charArray, -1, wString, 4096);
+//    return wString;
+//}
+//#endif

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -477,10 +477,6 @@ static void program_loop()
             uint32_t filesize = 0; // I could use stat, but it doesn't work in WinXP (more info below)
             local_reupload = false;
 
-            #ifndef LINUX
-            std::ifstream stream;
-            #endif
-
             // Try multiple times to open the file, because sometimes does not work the first time in Listen mode
             for (int i=0; i<5; i++) 
             {
@@ -490,7 +486,6 @@ static void program_loop()
                 HANDLE file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "rb");
-                stream = std::ifstream(fp);
                 #else
                 fp = fopen(device_getrom(), "rb");
                 #endif
@@ -543,10 +538,6 @@ static void program_loop()
                 log_replace("ROM upload cancelled by the user.\n", CRDEF_ERROR);
             
             // Update variables and close the file
-            #ifndef LINUX
-            stream.close();
-            #endif
-
             lastmodtime = newmodtime;
             fclose(fp);
         }

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -18,12 +18,6 @@ UNFLoader Entrypoint
 #include <thread>
 #include <chrono>
 
-
-// For _fsopen on windows
-//#ifndef LINUX
-//#include <share.h>
-//#endif
-
 /*********************************
               Macros
 *********************************/

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -484,13 +484,10 @@ static void program_loop()
             for (int i=0; i<5; i++) 
             {
                 // On windows, fopen will lock the file, so hot-reload features will not work.
-                // You have to use _fsopen and specify you want to allow shared access.
+                // You have to use manually specify a handle.
                 #ifndef LINUX
                 const char* fileName = device_getrom();
-                size_t length = strlen(fileName);
-                std::wstring text_wchar(length, L'#');
-                mbstowcs(&text_wchar[0], fileName , length);
-                file_handle = CreateFileW(text_wchar.data(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                file_handle = CreateFileA(fileName, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "rb");
                 #else
@@ -545,9 +542,6 @@ static void program_loop()
                 log_replace("ROM upload cancelled by the user.\n", CRDEF_ERROR);
             
             // Update variables and close the file
-            #ifndef LINUX
-            CloseHandle(file_handle);
-            #endif
             lastmodtime = newmodtime;
             fclose(fp);
         }

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -477,13 +477,17 @@ static void program_loop()
             uint32_t filesize = 0; // I could use stat, but it doesn't work in WinXP (more info below)
             local_reupload = false;
 
+            #ifndef LINUX
+            HANDLE file_handle;
+            #endif
+
             // Try multiple times to open the file, because sometimes does not work the first time in Listen mode
             for (int i=0; i<5; i++) 
             {
                 // On windows, fopen will lock the file, so hot-reload features will not work.
                 // You have to use _fsopen and specify you want to allow shared access.
                 #ifndef LINUX
-                HANDLE file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "rb");
                 #else
@@ -538,6 +542,9 @@ static void program_loop()
                 log_replace("ROM upload cancelled by the user.\n", CRDEF_ERROR);
             
             // Update variables and close the file
+            #ifndef LINUX
+            CloseHandle(file_handle);
+            #endif
             lastmodtime = newmodtime;
             fclose(fp);
         }

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -20,7 +20,6 @@ UNFLoader Entrypoint
 
 // For _fsopen on windows
 #ifndef LINUX
-#include <fstream>
 #include <share.h>
 #include <windows.h>
 #include <fcntl.h>

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -72,10 +72,6 @@ static std::list<char*>  local_args;
 static std::atomic<int>  local_esclevel (0);
 static std::atomic<bool> local_reupload (false);
 
-// Local funcs
-//#ifndef LINUX
-//wchar_t *convertCharArrayToLPCWSTR(const char* charArray);
-//#endif
 
 /*==============================
     main
@@ -493,7 +489,7 @@ static void program_loop()
                 #ifndef LINUX
                 HANDLE file_handle = CreateFileA(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
-                fp = _fdopen(file_descriptor, "r");
+                fp = _fdopen(file_descriptor, "rb");
                 stream = std::ifstream(fp);
                 #else
                 fp = fopen(device_getrom(), "rb");
@@ -898,12 +894,3 @@ static void show_help()
     if (!term_isusingcurses())
         while ((category = getchar()) != '\n' && category != EOF);
 }
-
-//#ifndef LINUX
-//wchar_t *convertCharArrayToLPCWSTR(const char* charArray)
-//{
-//    wchar_t* wString=new wchar_t[4096];
-//    MultiByteToWideChar(CP_ACP, 0, charArray, -1, wString, 4096);
-//    return wString;
-//}
-//#endif

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -19,6 +19,11 @@ UNFLoader Entrypoint
 #include <chrono>
 
 
+// For _fsopen on windows
+//#ifndef LINUX
+//#include <share.h>
+//#endif
+
 /*********************************
               Macros
 *********************************/
@@ -472,7 +477,13 @@ static void program_loop()
             // Try multiple times to open the file, because sometimes does not work the first time in Listen mode
             for (int i=0; i<5; i++) 
             {
+                // On windows, fopen will lock the file, so hot-reload features will not work.
+                // You have to use _fsopen and specify you want to allow shared access.
+                #ifndef LINUX
+                fp = _fsopen(device_getrom(), "rb", _SH_DENYNO );
+                #else
                 fp = fopen(device_getrom(), "rb");
+                #endif
                 if (fp != NULL)
                     break;
                 else

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -23,6 +23,8 @@ UNFLoader Entrypoint
 #include <fstream>
 #include <share.h>
 #include <windows.h>
+#include <fcntl.h>
+#include <io.h>
 #endif
 
 /*********************************
@@ -488,7 +490,7 @@ static void program_loop()
                 HANDLE file_handle = CreateFile(device_getrom(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "r");
-                stream(file)
+                stream = std::ifstream(fp);
                 #else
                 fp = fopen(device_getrom(), "rb");
                 #endif

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -20,7 +20,6 @@ UNFLoader Entrypoint
 
 // For _fsopen on windows
 #ifndef LINUX
-#include <share.h>
 #include <windows.h>
 #include <fcntl.h>
 #include <io.h>
@@ -490,7 +489,8 @@ static void program_loop()
                 const char* fileName = device_getrom();
                 size_t length = strlen(fileName);
                 std::wstring text_wchar(length, L'#');
-                file_handle = CreateFileA( mbstowcs(&text_wchar[0], fileName , length), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                mbstowcs(&text_wchar[0], fileName , length);
+                file_handle = CreateFileW(text_wchar.data(), GENERIC_READ, FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 int file_descriptor = _open_osfhandle((intptr_t)file_handle, _O_RDONLY);
                 fp = _fdopen(file_descriptor, "rb");
                 #else


### PR DESCRIPTION
## Description
in windows, using the `fopen` function locks the file for other programs. Therefore, the hot-reloading features would not work on windows. This behaviour is described in the documentation for `fopen_s`,  but it can be assumed to apply to `fopen` as well. This is an attempt to fix that given the documentations recommendations to use _fsopen with explictly set shared file access permissions instead.

This was tried at first, but it appeared to not be sufficient, as _fsopen does not have any permission set that allows files to be removed - you have to use lower level WinAPI functions to open files in a way that allows other applications to delete them. 

## Motivation and Context
As discussed on Discord!

## How Has This Been Tested?
I am testing this now with the PR build, since I was struggling to set up the Windows build on my machine. will make further commits if it doesn't work!


