### PR TITLE
Add gopher64 support

### DIFF
--- a/UNFLoader/FlashcartLib_Dynamic.vcxproj
+++ b/UNFLoader/FlashcartLib_Dynamic.vcxproj
@@ -109,7 +109,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Include/ftd2xx.lib;shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/ftd2xx.lib;shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -130,7 +130,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Include/ftd2xx.lib;shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/ftd2xx.lib;shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -179,6 +179,7 @@
     <ClInclude Include="device_64drive.h" />
     <ClInclude Include="device_everdrive.h" />
     <ClInclude Include="device_sc64.h" />
+    <ClInclude Include="device_gopher64.h" />
     <ClInclude Include="include\ftd2xx.h" />
   </ItemGroup>
   <ItemGroup>
@@ -187,6 +188,7 @@
     <ClCompile Include="device_64drive.cpp" />
     <ClCompile Include="device_everdrive.cpp" />
     <ClCompile Include="device_sc64.cpp" />
+    <ClCompile Include="device_gopher64.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/UNFLoader/FlashcartLib_Dynamic.vcxproj.filters
+++ b/UNFLoader/FlashcartLib_Dynamic.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="device_sc64.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="device_gopher64.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\ftd2xx.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="device_sc64.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="device_gopher64.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/UNFLoader/FlashcartLib_Static.vcxproj
+++ b/UNFLoader/FlashcartLib_Static.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="device_64drive.h" />
     <ClInclude Include="device_everdrive.h" />
     <ClInclude Include="device_sc64.h" />
+    <ClInclude Include="device_gopher64.h" />
     <ClInclude Include="include\ftd2xx.h" />
   </ItemGroup>
   <ItemGroup>
@@ -197,6 +198,7 @@
     <ClCompile Include="device_64drive.cpp" />
     <ClCompile Include="device_everdrive.cpp" />
     <ClCompile Include="device_sc64.cpp" />
+    <ClCompile Include="device_gopher64.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/UNFLoader/FlashcartLib_Static.vcxproj.filters
+++ b/UNFLoader/FlashcartLib_Static.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="device_sc64.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="device_gopher64.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\ftd2xx.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="device_sc64.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="device_gopher64.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/UNFLoader/Makefile
+++ b/UNFLoader/Makefile
@@ -11,7 +11,8 @@ CARTLIBFILES	= device.cpp \
 		  		  device_usb.cpp \
             	  device_64drive.cpp \
                   device_everdrive.cpp \
-                  device_sc64.cpp
+                  device_sc64.cpp \
+                  device_gopher64.cpp
 
 ifeq ($(DEBUG),1)
 	CARTLIBNAME := $(CARTLIBNAME)_d

--- a/UNFLoader/UNFLoader.vcxproj
+++ b/UNFLoader/UNFLoader.vcxproj
@@ -103,7 +103,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Include/pdcurses.lib;Debug/Flashcart_d.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/pdcurses.lib;Debug/Flashcart_d.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalOptions>/NODEFAULTLIB:LIBCMT %(AdditionalOptions)</AdditionalOptions>
@@ -124,7 +124,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Include/pdcurses_x64.lib;x64/Debug/Flashcart_x64_d.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/pdcurses_x64.lib;x64/Debug/Flashcart_x64_d.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <AdditionalOptions>/NODEFAULTLIB:LIBCMT %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -147,7 +147,7 @@
       </LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Include/pdcurses.lib;Release/Flashcart.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/pdcurses.lib;Release/Flashcart.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
@@ -180,7 +180,7 @@
       </LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Include/pdcurses_x64.lib;x64/Release/Flashcart_x64.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Include/pdcurses_x64.lib;x64/Release/Flashcart_x64.lib;wsock32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>

--- a/UNFLoader/device.cpp
+++ b/UNFLoader/device.cpp
@@ -8,6 +8,7 @@ Passes flashcart communication to more specific functions
 #include "device_64drive.h"
 #include "device_everdrive.h"
 #include "device_sc64.h"
+#include "device_gopher64.h"
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -40,6 +41,7 @@ static void device_set_64drive1(CartDevice* cart);
 static void device_set_64drive2(CartDevice* cart);
 static void device_set_everdrive(CartDevice* cart);
 static void device_set_sc64(CartDevice* cart);
+static void device_set_gopher64(CartDevice* cart);
 
 
 /*********************************
@@ -80,6 +82,18 @@ void device_initialize()
 
 DeviceError device_find()
 {
+    // Look for Gopher64
+    if ((local_cart.carttype == CART_NONE || local_cart.carttype == CART_GOPHER64))
+    {
+        DeviceError err = device_test_gopher64(&local_cart);
+        if (err == DEVICEERR_OK)
+            device_set_gopher64(&local_cart);
+        else if (err != DEVICEERR_NOTCART)
+            return err;
+        else if (local_cart.carttype == CART_GOPHER64)
+            return DEVICEERR_CARTFINDFAIL;
+    }
+
     // Look for 64drive HW1 (FT2232H Asynchronous FIFO mode)
     if ((local_cart.carttype == CART_NONE || local_cart.carttype == CART_64DRIVE1))
     {
@@ -88,6 +102,8 @@ DeviceError device_find()
             device_set_64drive1(&local_cart);
         else if (err != DEVICEERR_NOTCART)
             return err;
+        else if (local_cart.carttype == CART_64DRIVE1)
+            return DEVICEERR_CARTFINDFAIL;
     }
 
     // Look for 64drive HW2 (FT2232H Asynchronous FIFO mode)
@@ -98,6 +114,8 @@ DeviceError device_find()
             device_set_64drive2(&local_cart);
         else if (err != DEVICEERR_NOTCART)
             return err;
+        else if (local_cart.carttype == CART_64DRIVE2)
+            return DEVICEERR_CARTFINDFAIL;
     }
 
     // Look for an EverDrive
@@ -108,6 +126,8 @@ DeviceError device_find()
             device_set_everdrive(&local_cart);
         else if (err != DEVICEERR_NOTCART)
             return err;
+        else if (local_cart.carttype == CART_EVERDRIVE)
+            return DEVICEERR_CARTFINDFAIL;
     }
 
     // Look for SC64
@@ -118,6 +138,8 @@ DeviceError device_find()
             device_set_sc64(&local_cart);
         else if (err != DEVICEERR_NOTCART)
             return err;
+        else if (local_cart.carttype == CART_SC64)
+            return DEVICEERR_CARTFINDFAIL;
     }
 
     // Finish
@@ -217,6 +239,31 @@ static void device_set_sc64(CartDevice* cart)
     funcPointer_senddata = &device_senddata_sc64;
     funcPointer_receivedata = &device_receivedata_sc64;
     funcPointer_close = &device_close_sc64;
+}
+
+
+/*==============================
+    device_set_gopher64
+    Marks the cart as being Gopher64
+    @param A pointer to the cart context
+    @param The index of the cart
+==============================*/
+
+static void device_set_gopher64(CartDevice* cart)
+{
+    // Set cart settings
+    cart->carttype = CART_GOPHER64;
+
+    // Set function pointers
+    funcPointer_open = &device_open_gopher64;
+    funcPointer_maxromsize = &device_maxromsize_gopher64;
+    funcPointer_rompadding = &device_rompadding_gopher64;
+    funcPointer_explicitcic = &device_explicitcic_gopher64;
+    funcPointer_sendrom = &device_sendrom_gopher64;
+    funcPointer_testdebug = &device_testdebug_gopher64;
+    funcPointer_senddata = &device_senddata_gopher64;
+    funcPointer_receivedata = &device_receivedata_gopher64;
+    funcPointer_close = &device_close_gopher64;
 }
 
 

--- a/UNFLoader/device.h
+++ b/UNFLoader/device.h
@@ -25,7 +25,8 @@
         CART_64DRIVE1  = 1,
         CART_64DRIVE2  = 2,
         CART_EVERDRIVE = 3,
-        CART_SC64      = 4
+        CART_SC64      = 4,
+        CART_GOPHER64  = 5,
     } CartType;
 
     typedef enum {
@@ -57,7 +58,9 @@
         DATATYPE_HEADER     = 0x03,
         DATATYPE_SCREENSHOT = 0x04,
         DATATYPE_HEARTBEAT  = 0x05,
-        DATATYPE_RDBPACKET  = 0x06
+        DATATYPE_RDBPACKET  = 0x06,
+        DATATYPE_TCPTEST    = 0x07,
+        DATATYPE_ROMUPLOAD  = 0x08,
     } USBDataType;
 
     typedef enum {

--- a/UNFLoader/device_gopher64.cpp
+++ b/UNFLoader/device_gopher64.cpp
@@ -1,0 +1,362 @@
+/***************************************************************
+                       device_gopher64.cpp
+
+Handles Gopher64 TCP communication.
+***************************************************************/
+#include "device_gopher64.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netdb.h>
+#include <unistd.h>
+#endif
+
+#include <sys/types.h>
+#include <string.h>
+#include <fcntl.h>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+typedef struct
+{
+    int sockfd;
+    std::vector<byte> buffer;
+    uint32_t data_type;
+    uint32_t data_size;
+} Gopher64Device;
+
+/*==============================
+    device_test_gopher64
+    Attempts to find Gopher64 device
+    @param  A pointer to the cart context
+    @return DEVICEERR_OK if the cart is an Gopher64,
+            DEVICEERR_NOTCART if it isn't,
+            Any other device error if problems ocurred
+==============================*/
+
+DeviceError device_test_gopher64(CartDevice *cart)
+{
+    if (device_open_gopher64(cart) == DEVICEERR_OK)
+    {
+        byte data[3] = {'N', '6', '4'};
+        if (device_senddata_gopher64(cart, DATATYPE_TCPTEST, data, 3) == DEVICEERR_OK)
+        {
+            byte *buff = NULL;
+            uint32_t dataheader = 0;
+            std::this_thread::sleep_for(std::chrono::milliseconds(500)); // give gopher64 time to respond
+            if (device_receivedata_gopher64(cart, &dataheader, &buff) == DEVICEERR_OK)
+            {
+                USBDataType type = (USBDataType)(dataheader >> 24);
+                uint32_t size = dataheader & 0xFFFFFF;
+                if (type == DATATYPE_TCPTEST && size == 3 && memcmp(buff, "N64", 3) == 0)
+                {
+                    free(buff);
+                    if (device_close_gopher64(cart) == DEVICEERR_OK)
+                    {
+                        return DEVICEERR_OK;
+                    }
+                }
+                else
+                {
+                    free(buff);
+                    device_close_gopher64(cart);
+                    return DEVICEERR_NOTCART;
+                }
+            }
+            else
+            {
+                if (buff != NULL)
+                {
+                    free(buff);
+                }
+                device_close_gopher64(cart);
+                return DEVICEERR_NOTCART;
+            }
+        }
+        else
+        {
+            device_close_gopher64(cart);
+            return DEVICEERR_NOTCART;
+        }
+    }
+    return DEVICEERR_NOTCART;
+}
+
+/*==============================
+    device_maxromsize_gopher64
+    Gets the max ROM size that
+    the Gopher64 supports
+    @return The max ROM size
+==============================*/
+
+uint32_t device_maxromsize_gopher64()
+{
+    return 0xFC00000;
+}
+
+/*==============================
+    device_rompadding_gopher64
+    Calculates the correct ROM size
+    for uploading on the Gopher64
+    @param  The current ROM size
+    @return The correct ROM size
+            for uploading.
+==============================*/
+
+uint32_t device_rompadding_gopher64(uint32_t romsize)
+{
+    return romsize;
+}
+
+/*==============================
+    device_explicitcic_gopher64
+    Checks if the Gopher64 requires
+    explicitly stating the CIC, and
+    auto sets it based on the IPL if
+    so
+    @param  The 4KB bootcode
+    @return Whether the CIC was changed
+==============================*/
+
+bool device_explicitcic_gopher64(byte *bootcode)
+{
+    device_setcic(cic_from_bootcode(bootcode));
+    return true;
+}
+
+/*==============================
+    device_testdebug_gopher64
+    Checks whether the Gopher64 can use debug mode
+    @param  A pointer to the cart context
+    @return DEVICEERR_OK
+==============================*/
+
+DeviceError device_testdebug_gopher64(CartDevice *cart)
+{
+    (void)(cart); // Ignore unused paramater warning
+
+    // Gopher64 supports debug mode
+    return DEVICEERR_OK;
+}
+
+/*==============================
+    device_open_gopher64
+    Opens the TCP connection
+    @param  A pointer to the cart context
+    @return The device error, or OK
+==============================*/
+
+DeviceError device_open_gopher64(CartDevice *cart)
+{
+    struct addrinfo hints, *res;
+    Gopher64Device *device = new Gopher64Device;
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_socktype = SOCK_STREAM; // TCP
+
+    // Resolve localhost and port
+    if (getaddrinfo("localhost", "64000", &hints, &res) != 0)
+    {
+        delete device;
+        return DEVICEERR_NOTCART;
+    }
+
+    // Create socket
+    device->sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+
+    if (device->sockfd < 0)
+    {
+        freeaddrinfo(res);
+        delete device;
+        return DEVICEERR_NOTCART;
+    }
+
+    // Connect
+    if (connect(device->sockfd, res->ai_addr, res->ai_addrlen) < 0)
+    {
+#ifdef _WIN32
+        closesocket(device->sockfd);
+#else
+        close(device->sockfd);
+#endif
+        freeaddrinfo(res);
+        delete device;
+        return DEVICEERR_NOTCART;
+    }
+
+#ifdef _WIN32
+    u_long non_blocking = 1;
+    // Set the socket to non-blocking
+    if (ioctlsocket(device->sockfd, FIONBIO, &non_blocking) != 0)
+    {
+        closesocket(device->sockfd);
+        freeaddrinfo(res);
+        delete device;
+        return DEVICEERR_NOTCART;
+    }
+#else
+    int flags = fcntl(device->sockfd, F_GETFL, 0);
+    // Set the socket to non-blocking
+    if (fcntl(device->sockfd, F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        close(device->sockfd);
+        freeaddrinfo(res);
+        delete device;
+        return DEVICEERR_NOTCART;
+    }
+#endif
+
+    device->data_size = 0;
+    device->data_type = 0;
+    cart->structure = device;
+    return DEVICEERR_OK;
+}
+
+/*==============================
+    device_sendrom_gopher64
+    Sends the ROM to the flashcart
+    @param  A pointer to the cart context
+    @param  A pointer to the ROM to send
+    @param  The size of the ROM
+    @return The device error, or OK
+==============================*/
+
+DeviceError device_sendrom_gopher64(CartDevice *cart, byte *rom, uint32_t size)
+{
+    return device_senddata_gopher64(cart, DATATYPE_ROMUPLOAD, rom, size);
+}
+
+/*==============================
+    device_tcp_send_gopher64
+    Sends TCP data to Gopher64
+    @param  socket file descriptor
+    @param  A pointer to the data to send
+    @param  The size of the data
+    @return The device error, or OK
+==============================*/
+
+static DeviceError device_tcp_send_gopher64(int sockfd, void *data, uint32_t size)
+{
+    size_t total_sent = 0;
+
+    while (total_sent < size)
+    {
+        int sent = send(sockfd, (const char *)data + total_sent, size - total_sent, 0);
+        if (sent > 0)
+        {
+            total_sent += sent;
+        }
+    }
+    return DEVICEERR_OK;
+}
+
+/*==============================
+    device_senddata_gopher64
+    Sends data to Gopher64
+    @param  A pointer to the cart context
+    @param  The datatype that is being sent
+    @param  A buffer containing said data
+    @param  The size of the data
+    @return The device error, or OK
+==============================*/
+
+DeviceError device_senddata_gopher64(CartDevice *cart, USBDataType datatype, byte *data, uint32_t size)
+{
+    Gopher64Device *device = (Gopher64Device *)cart->structure;
+
+    uint32_t data_type = swap_endian((uint32_t)datatype);
+    if (device_tcp_send_gopher64(device->sockfd, &data_type, sizeof(uint32_t)) != DEVICEERR_OK)
+    {
+        return DEVICEERR_WRITEFAIL;
+    }
+    uint32_t swapped_size = swap_endian(size);
+    if (device_tcp_send_gopher64(device->sockfd, &swapped_size, sizeof(uint32_t)) != DEVICEERR_OK)
+    {
+        return DEVICEERR_WRITEFAIL;
+    }
+    if (device_tcp_send_gopher64(device->sockfd, data, size) != DEVICEERR_OK)
+    {
+        return DEVICEERR_WRITEFAIL;
+    }
+    return DEVICEERR_OK;
+}
+
+/*==============================
+    device_receivedata_gopher64
+    Receives data from Gopher64
+    @param  A pointer to the cart context
+    @param  A pointer to an 32-bit value where
+            the received data header will be
+            stored.
+    @param  A pointer to a byte buffer pointer
+            where the data will be malloc'ed into.
+    @return The device error, or OK
+==============================*/
+
+DeviceError device_receivedata_gopher64(CartDevice *cart, uint32_t *dataheader, byte **buff)
+{
+    *dataheader = 0;
+    *buff = NULL;
+
+    Gopher64Device *device = (Gopher64Device *)cart->structure;
+    char local_buffer[4096];
+
+    while (true)
+    {
+        int n = recv(device->sockfd, &local_buffer[0], sizeof(local_buffer), 0);
+        if (n > 0)
+            device->buffer.insert(device->buffer.end(), &local_buffer[0], &local_buffer[n]);
+        else
+            break;
+    }
+
+    if (device->data_type == 0 && device->buffer.size() >= sizeof(uint32_t))
+    {
+        memcpy(&device->data_type, device->buffer.data(), sizeof(uint32_t));
+        device->data_type = swap_endian(device->data_type);
+        device->buffer.erase(device->buffer.begin(), device->buffer.begin() + sizeof(uint32_t));
+    }
+    if (device->data_type != 0 && device->data_size == 0 && device->buffer.size() >= sizeof(uint32_t))
+    {
+        memcpy(&device->data_size, device->buffer.data(), sizeof(uint32_t));
+        device->data_size = swap_endian(device->data_size);
+        device->buffer.erase(device->buffer.begin(), device->buffer.begin() + sizeof(uint32_t));
+    }
+    if (device->data_type != 0 && device->data_size != 0)
+    {
+        if (device->buffer.size() >= device->data_size)
+        {
+            *dataheader = ((device->data_type & 0xFF) << 24) | (device->data_size & 0xFFFFFF);
+            *buff = (byte *)malloc(device->data_size);
+            memcpy(*buff, device->buffer.data(), device->data_size);
+            device->buffer.erase(device->buffer.begin(), device->buffer.begin() + device->data_size);
+            device->data_type = 0;
+            device->data_size = 0;
+            return DEVICEERR_OK;
+        }
+    }
+    return DEVICEERR_OK;
+}
+
+/*==============================
+    device_close_gopher64
+    Closes the TCP connection
+    @param  A pointer to the cart context
+    @return The device error, or OK
+==============================*/
+
+DeviceError device_close_gopher64(CartDevice *cart)
+{
+    Gopher64Device *device = (Gopher64Device *)cart->structure;
+#ifdef _WIN32
+    closesocket(device->sockfd);
+#else
+    close(device->sockfd);
+#endif
+    free(device);
+    cart->structure = NULL;
+    return DEVICEERR_OK;
+}

--- a/UNFLoader/device_gopher64.h
+++ b/UNFLoader/device_gopher64.h
@@ -1,0 +1,22 @@
+#ifndef __DEVICE_GOPHER64_HEADER
+#define __DEVICE_GOPHER64_HEADER
+
+    #include "device.h"
+
+
+    /*********************************
+            Function Prototypes
+    *********************************/
+
+    DeviceError device_test_gopher64(CartDevice* cart);
+    DeviceError device_open_gopher64(CartDevice* cart);
+    uint32_t    device_maxromsize_gopher64();
+    uint32_t    device_rompadding_gopher64(uint32_t romsize);
+    bool        device_explicitcic_gopher64(byte* bootcode);
+    DeviceError device_sendrom_gopher64(CartDevice* cart, byte* rom, uint32_t size);
+    DeviceError device_testdebug_gopher64(CartDevice* cart);
+    DeviceError device_senddata_gopher64(CartDevice* cart, USBDataType datatype, byte* data, uint32_t size);
+    DeviceError device_receivedata_gopher64(CartDevice* cart, uint32_t* dataheader, byte** buff);
+    DeviceError device_close_gopher64(CartDevice* cart);
+
+#endif

--- a/UNFLoader/helper.cpp
+++ b/UNFLoader/helper.cpp
@@ -32,7 +32,7 @@
 *********************************/
 
 // Useful constants for converting between enums and strings
-const char* cart_strings[] = {"64Drive HW1", "64Drive HW2", "EverDrive", "SC64"}; // In order of the CartType enums
+const char* cart_strings[] = {"64Drive HW1", "64Drive HW2", "EverDrive", "SC64", "Gopher64"}; // In order of the CartType enums
 const int   cart_strcount = sizeof(cart_strings)/sizeof(cart_strings[0]);
 const char* cic_strings[] = {"6101", "6102", "7101", "7102", "X103", "X105", "X106", "5101"}; // In order of the CICType enums
 const int   cic_strcount = sizeof(cic_strings)/sizeof(cic_strings[0]);
@@ -242,7 +242,7 @@ uint64_t time_miliseconds()
 CartType cart_strtotype(const char* cartstring)
 {
     // If the cart string is a single number, then it's pretty easy to get the cart enum
-    if (cartstring[0] >= ('0'+((int)CART_64DRIVE1)) && cartstring[0] <= ('0'+((int)CART_SC64)) && cartstring[1] == '\0')
+    if (cartstring[0] >= ('0'+((int)CART_64DRIVE1)) && cartstring[0] <= ('0'+((int)CART_GOPHER64)) && cartstring[1] == '\0')
         return (CartType)(cartstring[0]-'0');
 
     // Check if the user, for some reason, wrote the entire cart string out

--- a/UNFLoader/main.cpp
+++ b/UNFLoader/main.cpp
@@ -729,6 +729,7 @@ static void show_args()
     log_simple("  \t %d - %s\n", (int)CART_64DRIVE2, "64Drive HW2");
     log_simple("  \t %d - %s\n", (int)CART_EVERDRIVE, "EverDrive 3.0 or X7");
     log_simple("  \t %d - %s\n", (int)CART_SC64, "SC64");
+    log_simple("  \t %d - %s\n", (int)CART_GOPHER64, "Gopher64");
     log_simple("  -c <int>\t\t   Set CIC emulation (64Drive HW2 only).\n");
     log_simple("  \t %d - %s\t %d - %s\n", (int)CIC_6101, "6101 (NTSC)", (int)CIC_6102, "6102 (NTSC)");
     log_simple("  \t %d - %s\t %d - %s\n", (int)CIC_7101, "7101 (NTSC)", (int)CIC_7102, "7102 (PAL)");


### PR DESCRIPTION
## Description
This is a companion to this PR in Gopher64: https://github.com/gopher64/gopher64/pull/526

I have only tested this on Linux so far. The debug example ROM (Hello World and USB Read) work without issue. However, the NetLib ROMs don't seem to work correctly yet, for example:

<img width="1375" height="540" alt="Screenshot From 2025-07-23 19-25-42" src="https://github.com/user-attachments/assets/e5ce8371-3f3c-41de-999f-21dfc077bfa7" />

---

This driver works using TCP. Gopher64 starts a TCP server, and UNFLoader communicates with that TCP server. ROM uploading and regular read/writes are supported.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I wanted to add Netlib support to Gopher64 so that the potential was there to play with physical consoles.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
